### PR TITLE
feat(backend): entry-order 결제 연동 계약 구현 및 트랜잭션 안전성 개선

### DIFF
--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
@@ -77,10 +77,9 @@ public class EntryController {
 	@PostMapping("/confirm")
 	public ApiResponse<Void> confirmReservation(
 		@RequestHeader("X-User-Id") Long userId,
-		@PathVariable Long eventId,
 		@RequestParam Long paceId
 	) {
-		entryService.confirmReservation(userId, eventId, paceId);
+		entryService.confirmReservation(userId, paceId);
 		return ApiResponse.success();
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
@@ -1,0 +1,100 @@
+package com.kt.onrace.domain.entry.service;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.domain.entry.entity.Entry;
+import com.kt.onrace.domain.entry.entity.EntryStatus;
+import com.kt.onrace.domain.entry.repository.EntryRepository;
+import com.kt.onrace.domain.event.entity.Event;
+import com.kt.onrace.domain.event.entity.EventAppType;
+import com.kt.onrace.domain.event.repository.EventRepository;
+import com.kt.onrace.domain.event.service.EventStockService;
+import com.kt.onrace.domain.order.contract.OrderCheckoutEligibility;
+import com.kt.onrace.domain.order.contract.OrderEntryContract;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EntryContractService implements OrderEntryContract {
+
+	private final EntryRepository entryRepository;
+	private final EventRepository eventRepository;
+	private final EventStockService eventStockService;
+	private final EntryService entryService;
+
+	@Override
+	public OrderCheckoutEligibility resolveCheckoutEligibility(Long userId, Long eventId, Long paceId) {
+		Event event = eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eventId,
+			BusinessErrorCode.EVENT_NOT_FOUND);
+
+		Entry entry = entryRepository.findByUserIdAndEventIdOrThrow(userId, eventId, BusinessErrorCode.ENTRY_NOT_FOUND);
+
+		EventAppType appType = event.getAppType();
+
+		return switch (appType) {
+			case LOTTERY -> resolveLottery(entry, appType);
+			case FIRST_COME -> resolveFirstCome(entry, appType, paceId, userId);
+		};
+	}
+
+	private OrderCheckoutEligibility resolveLottery(Entry entry, EventAppType appType) {
+		boolean canCheckout = entry.getStatus() == EntryStatus.WON;
+		String failureCode = canCheckout ? null : BusinessErrorCode.ENTRY_CANNOT_APPLY.getCode();
+
+		return OrderCheckoutEligibility.builder()
+			.entryId(entry.getId())
+			.appType(appType)
+			.currentEntryStatus(entry.getStatus())
+			.requiredEntryStatus(EntryStatus.WON)
+			.reservedUntil(null)
+			.requiresReservationValidation(false)
+			.canCheckout(canCheckout)
+			.failureCode(failureCode)
+			.build();
+	}
+
+	private OrderCheckoutEligibility resolveFirstCome(Entry entry, EventAppType appType, Long paceId, Long userId) {
+		boolean isReserved = entry.isReserved();
+		boolean hasReservation = isReserved && eventStockService.hasReservation(paceId, userId);
+		boolean canCheckout = isReserved && hasReservation;
+
+		LocalDateTime reservedUntil = null;
+		if (canCheckout) {
+			long ttlMs = eventStockService.getReservationTtl(paceId, userId);
+			if (ttlMs > 0) {
+				reservedUntil = LocalDateTime.now().plusNanos(TimeUnit.MILLISECONDS.toNanos(ttlMs));
+			}
+		}
+
+		String failureCode = canCheckout ? null : BusinessErrorCode.ENTRY_RESERVATION_EXPIRED.getCode();
+
+		return OrderCheckoutEligibility.builder()
+			.entryId(entry.getId())
+			.appType(appType)
+			.currentEntryStatus(entry.getStatus())
+			.requiredEntryStatus(EntryStatus.RESERVED)
+			.reservedUntil(reservedUntil)
+			.requiresReservationValidation(true)
+			.canCheckout(canCheckout)
+			.failureCode(failureCode)
+			.build();
+	}
+
+	@Override
+	public boolean hasReservation(Long eventId, Long paceId, Long userId) {
+		return eventStockService.hasReservation(paceId, userId);
+	}
+
+	@Override
+	@Transactional
+	public void confirmReservation(Long userId, Long eventId, Long paceId) {
+		entryService.confirmReservation(userId, eventId, paceId);
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
@@ -88,13 +88,13 @@ public class EntryContractService implements OrderEntryContract {
 	}
 
 	@Override
-	public boolean hasReservation(Long eventId, Long paceId, Long userId) {
+	public boolean hasReservation(Long paceId, Long userId) {
 		return eventStockService.hasReservation(paceId, userId);
 	}
 
 	@Override
 	@Transactional
-	public void confirmReservation(Long userId, Long eventId, Long paceId) {
-		entryService.confirmReservation(userId, eventId, paceId);
+	public void confirmReservation(Long userId, Long paceId) {
+		entryService.confirmReservation(userId, paceId);
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -222,13 +222,12 @@ public class EntryService {
 	 */
 	@ServiceLog(slowMs = 2000)
 	@Transactional
-	public void confirmReservation(Long userId, Long eventId, Long paceId) {
+	public void confirmReservation(Long userId, Long paceId) {
 		Entry entry = entryRepository.findByUserIdAndEventPaceId(userId, paceId)
 			.orElseThrow(() -> new BusinessException(BusinessErrorCode.ENTRY_NOT_FOUND));
 
 		Preconditions.validate(entry.isReserved(), BusinessErrorCode.ENTRY_CANNOT_APPLY);
-		Preconditions.validate(
-			eventStockService.hasReservation(paceId, userId),
+		Preconditions.validate(eventStockService.hasReservation(paceId, userId),
 			BusinessErrorCode.ENTRY_RESERVATION_EXPIRED
 		);
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -3,6 +3,7 @@ package com.kt.onrace.domain.entry.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +11,7 @@ import com.kt.onrace.common.exception.BusinessErrorCode;
 import com.kt.onrace.common.exception.BusinessException;
 import com.kt.onrace.common.logging.annotation.ServiceLog;
 import com.kt.onrace.common.util.Preconditions;
+import com.kt.onrace.domain.entry.listener.ReservationConfirmedEvent;
 import com.kt.onrace.domain.entry.config.EntryProperties;
 import com.kt.onrace.domain.entry.dto.EntryApplyResponse;
 import com.kt.onrace.domain.entry.dto.EntryOverviewResponse;
@@ -48,6 +50,7 @@ public class EntryService {
 	private final MemberRepository memberRepository;
 	private final EventStockService eventStockService;
 	private final EventStockRepository eventStockRepository;
+	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@ServiceLog(slowMs = 2000)
 	@Transactional
@@ -214,29 +217,25 @@ public class EntryService {
 	}
 
 	/**
-	 * 결제 확정 — (테스트용 임시 코드입니다 추후에 제가 삭제하겠습니다)
+	 * 결제 확정 — RESERVED → APPLIED 전환, DB 확정 재고 증가
+	 * Redis 예약 키 삭제는 트랜잭션 커밋 후 ReservationConfirmedListener에서 처리
 	 */
 	@ServiceLog(slowMs = 2000)
 	@Transactional
 	public void confirmReservation(Long userId, Long eventId, Long paceId) {
-		log.info("[TEMP-LOG] confirmReservation 시작 - userId={}, paceId={}", userId, paceId);
 		Entry entry = entryRepository.findByUserIdAndEventPaceId(userId, paceId)
 			.orElseThrow(() -> new BusinessException(BusinessErrorCode.ENTRY_NOT_FOUND));
 
-		if (entry.getStatus() == EntryStatus.APPLIED) {
-			log.info("[TEMP-LOG] 이미 APPLIED 상태, 즉시 반환 - userId={}", userId);
-			return;
-		}
-
 		Preconditions.validate(entry.isReserved(), BusinessErrorCode.ENTRY_CANNOT_APPLY);
-
-		boolean deleted = eventStockService.deleteReservation(paceId, userId);
-		log.info("[TEMP-LOG] Redis 예약 키 삭제 결과 - deleted={}", deleted);
-		Preconditions.validate(deleted, BusinessErrorCode.ENTRY_RESERVATION_EXPIRED);
+		Preconditions.validate(
+			eventStockService.hasReservation(paceId, userId),
+			BusinessErrorCode.ENTRY_RESERVATION_EXPIRED
+		);
 
 		entry.confirmPayment();
 		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
-		log.info("[TEMP-LOG] confirmReservation 완료 - userId={}, status=APPLIED, confirmedStock++", userId);
+
+		applicationEventPublisher.publishEvent(new ReservationConfirmedEvent(paceId, userId));
 	}
 
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -55,27 +55,24 @@ public class EventStockService {
 		);
 	}
 
-	/**
-	 * (결제 확정 테스트용 임시 코드입니다 추후에 제가 삭제하겠습니다)
-	 */
+	public long getReservationTtl(Long paceId, Long userId) {
+		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
+		RBucket<String> bucket = redissonClient.getBucket(reservationKey, StringCodec.INSTANCE);
+		return bucket.remainTimeToLive();
+	}
+
 	public void restoreStock(Long paceId) {
 		String stockKey = RedisKeyGenerator.stockKey(paceId);
 		RAtomicLong stock = redissonClient.getAtomicLong(stockKey);
 		stock.incrementAndGet();
 	}
 
-	/**
-	 * (결제 확정 테스트용 임시 코드입니다 추후에 제가 삭제하겠습니다)
-	 */
 	public boolean hasReservation(Long paceId, Long userId) {
 		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
 		RBucket<String> bucket = redissonClient.getBucket(reservationKey, StringCodec.INSTANCE);
 		return bucket.isExists();
 	}
 
-	/**
-	 * (결제 확정 테스트용 임시 코드입니다 추후에 제가 삭제하겠습니다)
-	 */
 	public boolean deleteReservation(Long paceId, Long userId) {
 		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
 		RBucket<String> bucket = redissonClient.getBucket(reservationKey, StringCodec.INSTANCE);

--- a/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderCheckoutEligibility.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderCheckoutEligibility.java
@@ -5,11 +5,16 @@ import java.time.LocalDateTime;
 import com.kt.onrace.domain.entry.entity.EntryStatus;
 import com.kt.onrace.domain.event.entity.EventAppType;
 
+import lombok.Builder;
+
 /**
  * 주문/결제팀이 entry 도메인으로부터 받아야 하는 최소 결제 가능 계약.
  * LOTTERY는 WON, FIRST_COME은 RESERVED + reservedUntil/예약 유효성 확인을 전제로 한다.
  */
+
+@Builder
 public record OrderCheckoutEligibility(
+	Long entryId,
 	EventAppType appType,
 	EntryStatus currentEntryStatus,
 	EntryStatus requiredEntryStatus,

--- a/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderEntryContract.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderEntryContract.java
@@ -8,7 +8,7 @@ public interface OrderEntryContract {
 
 	OrderCheckoutEligibility resolveCheckoutEligibility(Long userId, Long eventId, Long paceId);
 
-	boolean hasReservation(Long eventId, Long paceId, Long userId);
+	boolean hasReservation(Long paceId, Long userId);
 
-	void confirmReservation(Long userId, Long eventId, Long paceId);
+	void confirmReservation(Long userId, Long paceId);
 }


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- EntryContractService 추가: OrderEntryContract 구현체로 order/payment 팀에 결제 연동 API 제공
- resolveCheckoutEligibility(): checkout 가능 여부 + entryId + 만료시각 반환
- hasReservation(): Redis 예약 유효 여부 확인
- confirmReservation(): 결제 완료 시 신청확정 + 재고확정 (원자적)
- OrderCheckoutEligibility에 entryId 필드 및 @Builder추가
- EventStockService에 getReservationTtl() 메서드 추가 (Redis 예약 TTL 조회)
- confirmReservation() 트랜잭션 안전성 개선
- Redis DEL을 @TransactionalEventListener(AFTER_COMMIT)으로 이동
- ReservationConfirmedEvent / ReservationConfirmedListener 추가
- DB 커밋 실패 시 Redis-DB 불일치 방지

## 📸 스크린샷 / 아키텍처 / 로그 (필수)
confirmReservation() 호출
  ├─ hasReservation(paceId, userId)     ← Redis 읽기만 (DEL 안 함)
  ├─ entry.confirmPayment()             ← RESERVED → APPLIED
  ├─ eventStock.confirmStock()          ← confirmedStock++
  ├─ publishEvent(ReservationConfirmedEvent)
  └─ TX COMMIT 
           ▼
  ReservationConfirmedListener (AFTER_COMMIT)
    └─ deleteReservation(paceId, userId)  ← Redis DEL

## ❓ 변경 이유 (Why)
- 마이페이지/주문 팀으로부터 결제 연동을 위한 4가지 협의사항 수신:
  1. checkout 가능 여부 판단을 entry에서 제공 가능한가?
  2. 응답에 entryId를 포함할 수 있는가?
  3. 선착순 예약의 TTL/만료시각 조회가 가능한가?
  4. 결제 완료 시 entry 상태 변경 책임을 entry가 담당할 수 있는가?
- checkout 판단 책임은 entry 도메인이 소유 (entry 상태 머신 규칙은 entry가 가장 잘 안다)
- 기존 confirmReservation()의 Redis DEL이 DB 커밋 전에 실행되어 불일치 위험 존재 → AFTER_COMMIT 패턴으로 안전성 확보


## 📋 체크리스트
- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
