### PR TITLE
[refactor(backend)] 대기열 구조 및 재고 신청 개선

### DIFF
--- a/backend/common/src/main/java/com/kt/onrace/common/exception/BusinessErrorCode.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/exception/BusinessErrorCode.java
@@ -86,6 +86,7 @@ public enum BusinessErrorCode implements ErrorCode {
 	ENTRY_RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "ENT_009", "만료되었습니다. 다시 신청해주세요."),
 	ENTRY_ALREADY_RESERVED(HttpStatus.CONFLICT, "ENT_010", "이미 선점한 이벤트입니다."),
 	ENTRY_EVENT_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "ENT_011", "종료된 이벤트입니다."),
+	ENTRY_QUEUE_PACE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_012", "대기열 토큰의 페이스와 신청 페이스가 일치하지 않습니다."),
 
 	// STOCK
 	STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STK_001", "재고 정보를 찾을 수 없습니다."),

--- a/backend/common/src/main/java/com/kt/onrace/common/util/RedisKeyGenerator.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/util/RedisKeyGenerator.java
@@ -2,10 +2,7 @@ package com.kt.onrace.common.util;
 
 public class RedisKeyGenerator {
 
-	public static String lockKey(String resource, Long id) {
-		return String.format("lock:%s:%d", resource, id);
-	}
-
+	// AUTH
 	public static String refreshTokenKey(Long userId) {
 		return String.format("refresh_token:%d", userId);
 	}
@@ -70,24 +67,30 @@ public class RedisKeyGenerator {
 		return String.format("sms:find:ip_attempt:%s", ip);
 	}
 
-	public static String stockKey(Long paceId) {
-		return String.format("stock:pace:%d", paceId);
+	// STOCK
+	public static String totalStockKey(Long paceId) {
+		return String.format("stock:total:pace:%d", paceId);
+	}
+
+	public static String tempStockKey(Long paceId) {
+		return String.format("stock:temp:pace:%d", paceId);
+	}
+
+	public static String confirmStockKey(Long paceId) {
+		return String.format("stock:confirm:pace:%d", paceId);
 	}
 
 	public static String reservationKey(Long paceId, Long userId) {
-		return String.format("reservation:%d:%d", paceId, userId);
+		return String.format("stock:reservation:%d:%d", paceId, userId);
 	}
 
-	public static String stockInitializedKey(Long paceId) {
-		return String.format("stock:initialized:%d", paceId);
-	}
-
+	// QUEUE
 	public static String queueWaiting(Long paceId) {
-		return "queue:waiting:" + paceId;
+		return String.format("queue:waiting:%d", paceId);
 	}
 
 	public static String queuePass(Long paceId, Long userId) {
-		return "queue:pass:" + paceId + ":" + userId;
+		return String.format("queue:pass:%d:%d", paceId, userId);
 	}
 
 	public static String queueBatchLock() {

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/QueueStatusHeaderFilter.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/QueueStatusHeaderFilter.java
@@ -1,0 +1,59 @@
+package com.kt.onrace.gateway.filter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.kt.onrace.gateway.cache.QueueEventCache;
+
+import lombok.Data;
+
+// 신청 버튼 클릭 -> 재고 조회(일시품절, 매진, 가능) -> 가능 시 gateway에서 응답헤더에 이벤트 대기열 여부 포함
+@Component
+public class QueueStatusHeaderFilter extends AbstractGatewayFilterFactory<QueueStatusHeaderFilter.Config> {
+
+	private final QueueEventCache queueEventCache;
+
+	private static final String QUEUE_ENABLED_HEADER = "X-Queue-Enabled";
+	private static final Pattern EVENT_ID_PATTERN = Pattern.compile("/events/(\\d+)/");
+
+	public QueueStatusHeaderFilter(QueueEventCache queueEventCache) {
+		super(Config.class);
+		this.queueEventCache = queueEventCache;
+	}
+
+	@Override
+	public GatewayFilter apply(Config config) {
+		return (exchange, chain) -> {
+			Long eventId = extractEventId(exchange);
+
+			if (eventId != null) {
+				boolean enabled = queueEventCache.isQueueEnabled(eventId);
+				exchange.getResponse().getHeaders().add(QUEUE_ENABLED_HEADER, String.valueOf(enabled));
+			}
+
+			return chain.filter(exchange);
+		};
+	}
+
+	private Long extractEventId(ServerWebExchange exchange) {
+		String path = exchange.getRequest().getURI().getPath();
+		Matcher matcher = EVENT_ID_PATTERN.matcher(path);
+		if (matcher.find()) {
+			try {
+				return Long.parseLong(matcher.group(1));
+			} catch (NumberFormatException e) {
+				return null;
+			}
+		}
+		return null;
+	}
+
+	@Data
+	public static class Config {
+	}
+}

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/QueueStatusHeaderFilter.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/QueueStatusHeaderFilter.java
@@ -33,7 +33,7 @@ public class QueueStatusHeaderFilter extends AbstractGatewayFilterFactory<QueueS
 
 			if (eventId != null) {
 				boolean enabled = queueEventCache.isQueueEnabled(eventId);
-				exchange.getResponse().getHeaders().add(QUEUE_ENABLED_HEADER, String.valueOf(enabled));
+				exchange.getResponse().getHeaders().set(QUEUE_ENABLED_HEADER, String.valueOf(enabled));
 			}
 
 			return chain.filter(exchange);

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/WaitingRoomFilter.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/WaitingRoomFilter.java
@@ -1,6 +1,7 @@
 package com.kt.onrace.gateway.filter;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -11,6 +12,7 @@ import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFac
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -32,7 +34,9 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 	private final QueueEventCache queueEventCache;
 
 	private static final String PASS_TOKEN_HEADER = "X-Queue-Token";
+	private static final String QUEUE_PACE_ID_HEADER = "X-Queue-Pace-Id";
 	private static final String QUEUE_PASS_TYPE = "QUEUE_PASS";
+	private static final String CLAIM_PACE_ID = "CLAIM_PACE_ID";
 	private static final Pattern EVENT_ID_PATTERN = Pattern.compile("/events/(\\d+)/");
 
 	public WaitingRoomFilter(GatewayProperties gatewayProperties, QueueEventCache queueEventCache) {
@@ -57,11 +61,15 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 
 			String passToken = exchange.getRequest().getHeaders().getFirst(PASS_TOKEN_HEADER);
 
-			if (passToken == null || !isValidQueuePassToken(passToken)) {
+			Optional<Long> paceId = extractPaceIdFromToken(passToken);
+			if (paceId.isEmpty()) {
 				return sendQueueRequired(exchange, config);
 			}
 
-			return chain.filter(exchange);
+			ServerHttpRequest mutatedRequest = exchange.getRequest().mutate()
+				.header(QUEUE_PACE_ID_HEADER, String.valueOf(paceId.get()))
+				.build();
+			return chain.filter(exchange.mutate().request(mutatedRequest).build());
 		};
 	}
 
@@ -90,16 +98,25 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 		return response.writeWith(Mono.just(buffer));
 	}
 
-	private boolean isValidQueuePassToken(String token) {
+	private Optional<Long> extractPaceIdFromToken(String token) {
+		if (token == null) {
+			return Optional.empty();
+		}
 		try {
 			Claims claims = Jwts.parser()
 				.verifyWith(queueTokenKey)
 				.build()
 				.parseSignedClaims(token)
 				.getPayload();
-			return QUEUE_PASS_TYPE.equals(claims.get("type", String.class));
+
+			if (!QUEUE_PASS_TYPE.equals(claims.get("type", String.class))) {
+				return Optional.empty();
+			}
+
+			Long paceId = claims.get(CLAIM_PACE_ID, Long.class);
+			return Optional.ofNullable(paceId);
 		} catch (JwtException | IllegalArgumentException e) {
-			return false;
+			return Optional.empty();
 		}
 	}
 

--- a/backend/gateway/src/main/resources/application.yml
+++ b/backend/gateway/src/main/resources/application.yml
@@ -31,6 +31,7 @@ spring:
                 exposed-headers:
                   - Authorization
                   - X-Request-Id
+                  - X-Queue-Enabled
                 allow-credentials: true
                 max-age: 3600
           routes:
@@ -52,16 +53,32 @@ spring:
               predicates:
                 - Path=/queue/**
               filters:
+                - name: BotDetectionFilter
+                  args:
+                    challengeUri: ${CHALLENGE_URI:http://localhost:3000/challenge}
                 - name: RequestRateLimiter
                   args:
                     redis-rate-limiter.replenishRate: 50
                     redis-rate-limiter.burstCapacity: 100
                     redis-rate-limiter.requestedTokens: 1
                     key-resolver: "#{@userOrIpKeyResolver}"
-            - id: ticketing-route
+            - id: entry-apply-lottery-route
               uri: ${MAIN_SERVICE_URI:http://localhost:8082}
               predicates:
-                - Path=/main/tickets/**
+                - Path=/main/events/*/entries/apply/lottery
+              filters:
+                - StripPrefix=1
+                - SetRequestHeader=X-Forwarded-Prefix, /main
+                - name: RequestRateLimiter
+                  args:
+                    redis-rate-limiter.replenishRate: 10
+                    redis-rate-limiter.burstCapacity: 20
+                    redis-rate-limiter.requestedTokens: 1
+                    key-resolver: "#{@userOrIpKeyResolver}"
+            - id: entry-apply-first-come-route
+              uri: ${MAIN_SERVICE_URI:http://localhost:8082}
+              predicates:
+                - Path=/main/events/*/entries/apply/first-come
               filters:
                 - StripPrefix=1
                 - SetRequestHeader=X-Forwarded-Prefix, /main
@@ -73,27 +90,24 @@ spring:
                     key-resolver: "#{@userOrIpKeyResolver}"
                 - name: BotDetectionFilter
                   args:
-                    challengeMode: true
                     challengeUri: ${CHALLENGE_URI:http://localhost:3000/challenge}
                 - name: WaitingRoomFilter
                   args:
                     queueUrl: ${WAITING_ROOM_URI:http://localhost:3000/queue}
-            - id: entry-apply-route
+            - id: stock-check-route
               uri: ${MAIN_SERVICE_URI:http://localhost:8082}
               predicates:
-                - Path=/main/events/*/entries/apply
+                - Path=/main/events/*/entries/stock-check
               filters:
                 - StripPrefix=1
                 - SetRequestHeader=X-Forwarded-Prefix, /main
+                - name: QueueStatusHeaderFilter
                 - name: RequestRateLimiter
                   args:
-                    redis-rate-limiter.replenishRate: 10
-                    redis-rate-limiter.burstCapacity: 20
+                    redis-rate-limiter.replenishRate: 50
+                    redis-rate-limiter.burstCapacity: 100
                     redis-rate-limiter.requestedTokens: 1
                     key-resolver: "#{@userOrIpKeyResolver}"
-                - name: WaitingRoomFilter
-                  args:
-                    queueUrl: ${WAITING_ROOM_URI:http://localhost:3000/queue}
             - id: public-route
               uri: ${MAIN_SERVICE_URI:http://localhost:8082}
               predicates:

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
@@ -86,7 +86,7 @@ public class EntryController {
 
 	@GetMapping("/stock-check")
 	public ApiResponse<EntryStockCheckResponse> checkStock(
-		@PathVariable String eventId,
+		@PathVariable Long eventId,
 		@RequestParam Long paceId
 		) {
 		return ApiResponse.success(entryService.checkStock(paceId));

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
@@ -17,6 +17,7 @@ import com.kt.onrace.domain.entry.dto.EntryOverviewResponse;
 import com.kt.onrace.domain.entry.dto.EntryCoursePaceRequest;
 import com.kt.onrace.domain.entry.dto.EntryPreSaveResponse;
 import com.kt.onrace.domain.entry.dto.EntryRateResponse;
+import com.kt.onrace.domain.entry.dto.EntryStockCheckResponse;
 import com.kt.onrace.domain.entry.service.EntryService;
 
 import jakarta.validation.Valid;
@@ -64,13 +65,31 @@ public class EntryController {
 		return ApiResponse.success(entryService.deletePreSave(userId, eventId));
 	}
 
-	@PostMapping("/apply")
-	public ApiResponse<EntryApplyResponse> apply(
+	@PostMapping("/apply/lottery")
+	public ApiResponse<EntryApplyResponse> applyLottery(
 		@RequestHeader("X-User-Id") Long userId,
 		@PathVariable Long eventId,
 		@Valid @RequestBody EntryCoursePaceRequest request
 	) {
-		return ApiResponse.success(entryService.apply(userId, eventId, request));
+		return ApiResponse.success(entryService.apply(userId, eventId, request, null));
+	}
+
+	@PostMapping("/apply/first-come")
+	public ApiResponse<EntryApplyResponse> applyFirstCome(
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestHeader(value = "X-Queue-Pace-Id", required = false) Long queuePaceId,
+		@PathVariable Long eventId,
+		@Valid @RequestBody EntryCoursePaceRequest request
+	) {
+		return ApiResponse.success(entryService.apply(userId, eventId, request, queuePaceId));
+	}
+
+	@GetMapping("/stock-check")
+	public ApiResponse<EntryStockCheckResponse> checkStock(
+		@PathVariable String eventId,
+		@RequestParam Long paceId
+		) {
+		return ApiResponse.success(entryService.checkStock(paceId));
 	}
 
 	// TODO: 결제 API 연동 후 제거 — 테스트용 임시 API입니다 추후에 제가 삭제하겠습니다

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/dto/EntryStockCheckResponse.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/dto/EntryStockCheckResponse.java
@@ -1,0 +1,34 @@
+package com.kt.onrace.domain.entry.dto;
+
+import com.kt.onrace.domain.entry.entity.EntryStockStatus;
+
+import lombok.Builder;
+
+@Builder
+public record EntryStockCheckResponse(
+	EntryStockStatus stockStatus,
+	long remainingStock
+) {
+
+	public static EntryStockCheckResponse available(long remainingStock) {
+		return EntryStockCheckResponse.builder()
+			.stockStatus(EntryStockStatus.AVAILABLE)
+			.remainingStock(remainingStock)
+			.build();
+	}
+
+	public static EntryStockCheckResponse tempSoldOut() {
+		return EntryStockCheckResponse.builder()
+			.stockStatus(EntryStockStatus.TEMP_SOLD_OUT)
+			.remainingStock(0)
+			.build();
+	}
+
+	public static EntryStockCheckResponse soldOut() {
+		return EntryStockCheckResponse.builder()
+			.stockStatus(EntryStockStatus.SOLD_OUT)
+			.remainingStock(0)
+			.build();
+	}
+
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/entity/EntryStockStatus.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/entity/EntryStockStatus.java
@@ -1,0 +1,14 @@
+package com.kt.onrace.domain.entry.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EntryStockStatus {
+	AVAILABLE("재고있음"),
+	TEMP_SOLD_OUT("일시품절"),
+	SOLD_OUT("품절");
+
+	private final String description;
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/listener/EntryExpListener.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/listener/EntryExpListener.java
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class EntryExpListener {
 
-	private static final String RESERVATION_PREFIX = "reservation:";
+	private static final String RESERVATION_PREFIX = "stock:reservation:";
 	private static final String EXPIRATION_PATTERN = "__keyevent@*__:expired";
 
 	private final RedissonClient redissonClient;

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -11,7 +11,7 @@ import com.kt.onrace.common.exception.BusinessErrorCode;
 import com.kt.onrace.common.exception.BusinessException;
 import com.kt.onrace.common.logging.annotation.ServiceLog;
 import com.kt.onrace.common.util.Preconditions;
-import com.kt.onrace.domain.entry.listener.ReservationConfirmedEvent;
+import com.kt.onrace.domain.entry.dto.EntryStockCheckResponse;
 import com.kt.onrace.domain.entry.config.EntryProperties;
 import com.kt.onrace.domain.entry.dto.EntryApplyResponse;
 import com.kt.onrace.domain.entry.dto.EntryOverviewResponse;
@@ -26,6 +26,7 @@ import com.kt.onrace.domain.event.entity.Event;
 import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventStatus;
+import com.kt.onrace.domain.event.entity.EventStock;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
@@ -154,7 +155,11 @@ public class EntryService {
 
 	@ServiceLog(slowMs = 2000)
 	@Transactional
-	public EntryApplyResponse apply(Long userId, Long eventId, EntryCoursePaceRequest request) {
+	public EntryApplyResponse apply(Long userId, Long eventId, EntryCoursePaceRequest request, Long queuePaceId) {
+		if (queuePaceId != null) {
+			Preconditions.validate(queuePaceId.equals(request.paceId()), BusinessErrorCode.ENTRY_QUEUE_PACE_MISMATCH);
+		}
+
 		memberRepository.findByIdAndIsDeletedFalseOrThrow(userId, BusinessErrorCode.MEMBER_NOT_FOUND);
 
 		Event event = eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eventId,
@@ -216,6 +221,22 @@ public class EntryService {
 			);
 	}
 
+	@ServiceLog
+	public EntryStockCheckResponse checkStock(Long paceId) {
+		long available = eventStockService.getTempStock(paceId);
+
+		if(available > 0)
+			return EntryStockCheckResponse.available(available);
+
+		long total = eventStockService.getTotalStock(paceId);
+		long confirmed = eventStockService.getConfirmStock(paceId);
+
+		if(confirmed >= total)
+			return EntryStockCheckResponse.soldOut();
+
+		return EntryStockCheckResponse.tempSoldOut();
+	}
+
 	/**
 	 * 결제 확정 — RESERVED → APPLIED 전환, DB 확정 재고 증가
 	 * Redis 예약 키 삭제는 트랜잭션 커밋 후 ReservationConfirmedListener에서 처리
@@ -234,7 +255,8 @@ public class EntryService {
 		entry.confirmPayment();
 		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
 
-		applicationEventPublisher.publishEvent(new ReservationConfirmedEvent(paceId, userId));
+		eventStockService.deleteReservation(paceId, userId);
+		eventStockService.confirmStock(paceId);
 	}
 
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -3,7 +3,6 @@ package com.kt.onrace.domain.entry.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +25,6 @@ import com.kt.onrace.domain.event.entity.Event;
 import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventStatus;
-import com.kt.onrace.domain.event.entity.EventStock;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
@@ -51,7 +49,6 @@ public class EntryService {
 	private final MemberRepository memberRepository;
 	private final EventStockService eventStockService;
 	private final EventStockRepository eventStockRepository;
-	private final ApplicationEventPublisher applicationEventPublisher;
 
 	@ServiceLog(slowMs = 2000)
 	@Transactional
@@ -240,8 +237,7 @@ public class EntryService {
 	}
 
 	/**
-	 * 결제 확정 — RESERVED → APPLIED 전환, DB 확정 재고 증가
-	 * Redis 예약 키 삭제는 트랜잭션 커밋 후 ReservationConfirmedListener에서 처리
+	 * 결제 확정 — RESERVED → APPLIED 전환, DB·Redis 확정 재고 증가 및 예약 키 삭제
 	 */
 	@ServiceLog(slowMs = 2000)
 	@Transactional

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -225,14 +225,16 @@ public class EntryService {
 	public EntryStockCheckResponse checkStock(Long paceId) {
 		long available = eventStockService.getTempStock(paceId);
 
-		if(available > 0)
+		if(available > 0) {
 			return EntryStockCheckResponse.available(available);
+		}
 
 		long total = eventStockService.getTotalStock(paceId);
 		long confirmed = eventStockService.getConfirmStock(paceId);
 
-		if(confirmed >= total)
+		if(confirmed >= total) {
 			return EntryStockCheckResponse.soldOut();
+		}
 
 		return EntryStockCheckResponse.tempSoldOut();
 	}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockInitializer.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockInitializer.java
@@ -12,7 +12,9 @@ import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventStockRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,7 +33,9 @@ public class EventStockInitializer {
 
 		for (EventPace pace : paces) {
 			EventStock eventStock = eventStockRepository.findByEventPaceIdOrThrow(pace.getId());
-			eventStockService.initializeStock(pace.getId(), eventStock.getAvailableStock());
+			log.debug("Initializing stock for EventPace ID: {}, Total Stock: {}, Confirmed Stock: {}",
+					pace.getId(), eventStock.getTotalStock(), eventStock.getConfirmedStock());
+			eventStockService.initializeStock(pace.getId(), eventStock.getTotalStock(), eventStock.getConfirmedStock());
 		}
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -26,22 +26,19 @@ public class EventStockService {
 			"redis.call('SET', KEYS[1], '1', 'EX', ARGV[1]) " +
 			"return stock"; // 스크립트가 한개이고 짧아서 외부 파일로 관리하지 않고 코드 내에 직접 작성(분리해도 됩니다)
 
-	public void initializeStock(Long paceId, int availableStock) {
-
+	public void initializeStock(Long paceId, int totalStock, int confirmedStock) {
 		// 재고 카운터 셋팅(이 부분은 추후에 어떻게 할지 고민해봐야할듯)
-		String stockKey = RedisKeyGenerator.stockKey(paceId);
-		RAtomicLong stock = redissonClient.getAtomicLong(stockKey);
-		stock.set(availableStock);
+		RAtomicLong total = redissonClient.getAtomicLong(RedisKeyGenerator.totalStockKey(paceId));
+		total.set(totalStock);
 
-		String initKey = RedisKeyGenerator.stockInitializedKey(paceId);
-		RBucket<String> flag = redissonClient.getBucket(initKey, StringCodec.INSTANCE);
-		flag.set("1");
+		RAtomicLong temp = redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId));
+		temp.set(totalStock - confirmedStock);
+
+		RAtomicLong confirm = redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId));
+		confirm.set(confirmedStock);
 	}
 
 	public long tryReserveStock(Long paceId, Long userId) {
-		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
-		String stockKey = RedisKeyGenerator.stockKey(paceId);
-
 		RScript script = redissonClient.getScript(StringCodec.INSTANCE);
 
 		// -2: 이미 선점된 경우, -1: 재고 부족, 0 이상: 선점 성공 (남은 재고 수)
@@ -50,33 +47,52 @@ public class EventStockService {
 			RScript.Mode.READ_WRITE,
 			RESERVE_SCRIPT,
 			RScript.ReturnType.INTEGER,
-			List.of(reservationKey, stockKey),
-			entryProperties.getTtlSeconds()
+			List.of(RedisKeyGenerator.reservationKey(paceId, userId), RedisKeyGenerator.tempStockKey(paceId)),
+			String.valueOf(entryProperties.getTtlSeconds())
 		);
 	}
 
+	public long getTotalStock(Long paceId) {
+		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.totalStockKey(paceId));
+		return stock.get();
+	}
+
+	public long getTempStock(Long paceId) {
+		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId));
+		return stock.get();
+	}
+
+	public long getConfirmStock(Long paceId) {
+		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId));
+		return stock.get();
+	}
+
 	public long getReservationTtl(Long paceId, Long userId) {
-		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
-		RBucket<String> bucket = redissonClient.getBucket(reservationKey, StringCodec.INSTANCE);
+		RBucket<String> bucket = redissonClient.getBucket(RedisKeyGenerator.reservationKey(paceId, userId),
+			StringCodec.INSTANCE);
 		return bucket.remainTimeToLive();
 	}
 
 	public void restoreStock(Long paceId) {
-		String stockKey = RedisKeyGenerator.stockKey(paceId);
-		RAtomicLong stock = redissonClient.getAtomicLong(stockKey);
+		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId));
 		stock.incrementAndGet();
 	}
 
 	public boolean hasReservation(Long paceId, Long userId) {
-		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
-		RBucket<String> bucket = redissonClient.getBucket(reservationKey, StringCodec.INSTANCE);
+		RBucket<String> bucket = redissonClient.getBucket(RedisKeyGenerator.reservationKey(paceId, userId),
+			StringCodec.INSTANCE);
 		return bucket.isExists();
 	}
 
 	public boolean deleteReservation(Long paceId, Long userId) {
-		String reservationKey = RedisKeyGenerator.reservationKey(paceId, userId);
-		RBucket<String> bucket = redissonClient.getBucket(reservationKey, StringCodec.INSTANCE);
+		RBucket<String> bucket = redissonClient.getBucket(RedisKeyGenerator.reservationKey(paceId, userId),
+			StringCodec.INSTANCE);
 		return bucket.delete();
+	}
+
+	public void confirmStock(Long paceId) {
+		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId));
+		stock.incrementAndGet();
 	}
 
 }

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/controller/EntryControllerTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/controller/EntryControllerTest.java
@@ -1,0 +1,140 @@
+package com.kt.onrace.domain.entry.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kt.onrace.common.exception.GlobalExceptionHandler;
+import com.kt.onrace.common.filter.GatewayAccessFilter;
+import com.kt.onrace.domain.entry.dto.EntryApplyResponse;
+import com.kt.onrace.domain.entry.dto.EntryCoursePaceRequest;
+import com.kt.onrace.domain.entry.dto.EntryStockCheckResponse;
+import com.kt.onrace.domain.entry.service.EntryService;
+
+@WebMvcTest(
+	controllers = EntryController.class,
+	excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = GatewayAccessFilter.class)
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class EntryControllerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final Long USER_ID = 1L;
+	private static final Long EVENT_ID = 7L;
+	private static final Long COURSE_ID = 15L;
+	private static final Long PACE_ID = 26L;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private EntryService entryService;
+
+	@Test
+	@DisplayName("응모 신청 성공 시 200과 엔트리 응답을 반환한다")
+	void applyLottery_success() throws Exception {
+		EntryApplyResponse response = new EntryApplyResponse(1L, EVENT_ID, "신청완료", null, null, null);
+		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull()))
+			.willReturn(response);
+
+		mockMvc.perform(post("/events/{eventId}/entries/apply/lottery", EVENT_ID)
+				.header(USER_ID_HEADER, USER_ID)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new EntryCoursePaceRequest(COURSE_ID, PACE_ID))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.entryId").value(1L))
+			.andExpect(jsonPath("$.data.status").value("신청완료"));
+
+		verify(entryService).apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull());
+	}
+
+	@Test
+	@DisplayName("선착순 신청 성공 시 200과 예약 응답을 반환한다")
+	void applyFirstCome_success() throws Exception {
+		LocalDateTime reservedUntil = LocalDateTime.of(2026, 4, 1, 12, 10, 0);
+		EntryApplyResponse response = new EntryApplyResponse(1L, EVENT_ID, "선점완료", reservedUntil, null, null);
+		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull()))
+			.willReturn(response);
+
+		mockMvc.perform(post("/events/{eventId}/entries/apply/first-come", EVENT_ID)
+				.header(USER_ID_HEADER, USER_ID)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new EntryCoursePaceRequest(COURSE_ID, PACE_ID))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.status").value("선점완료"))
+			.andExpect(jsonPath("$.data.reservedUntil").isNotEmpty());
+	}
+
+	@Test
+	@DisplayName("선착순 신청 시 X-Queue-Pace-Id 헤더가 서비스에 전달된다")
+	void applyFirstCome_withQueuePaceId() throws Exception {
+		EntryApplyResponse response = new EntryApplyResponse(1L, EVENT_ID, "선점완료", null, null, null);
+		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), eq(PACE_ID)))
+			.willReturn(response);
+
+		mockMvc.perform(post("/events/{eventId}/entries/apply/first-come", EVENT_ID)
+				.header(USER_ID_HEADER, USER_ID)
+				.header("X-Queue-Pace-Id", PACE_ID)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(new EntryCoursePaceRequest(COURSE_ID, PACE_ID))))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		verify(entryService).apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), eq(PACE_ID));
+	}
+
+	@Test
+	@DisplayName("재고 조회 성공 시 200과 재고 상태를 반환한다")
+	void checkStock_success() throws Exception {
+		given(entryService.checkStock(PACE_ID)).willReturn(EntryStockCheckResponse.available(5));
+
+		mockMvc.perform(get("/events/{eventId}/entries/stock-check", EVENT_ID)
+				.param("paceId", String.valueOf(PACE_ID)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.stockStatus").value("AVAILABLE"))
+			.andExpect(jsonPath("$.data.remainingStock").value(5));
+	}
+
+	@Test
+	@DisplayName("결제 확정 성공 시 200을 반환한다")
+	void confirmReservation_success() throws Exception {
+		doNothing().when(entryService).confirmReservation(USER_ID, PACE_ID);
+
+		mockMvc.perform(post("/events/{eventId}/entries/confirm", EVENT_ID)
+				.header(USER_ID_HEADER, USER_ID)
+				.param("paceId", String.valueOf(PACE_ID)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true));
+
+		verify(entryService).confirmReservation(USER_ID, PACE_ID);
+	}
+}

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
@@ -1,0 +1,332 @@
+package com.kt.onrace.domain.entry.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.common.exception.BusinessException;
+import com.kt.onrace.domain.entry.config.EntryProperties;
+import com.kt.onrace.domain.entry.dto.EntryApplyResponse;
+import com.kt.onrace.domain.entry.dto.EntryCoursePaceRequest;
+import com.kt.onrace.domain.entry.dto.EntryStockCheckResponse;
+import com.kt.onrace.domain.entry.entity.Entry;
+import com.kt.onrace.domain.entry.entity.EntryStatus;
+import com.kt.onrace.domain.entry.entity.EntryStockStatus;
+import com.kt.onrace.domain.entry.repository.EntryRepository;
+import com.kt.onrace.domain.event.entity.Event;
+import com.kt.onrace.domain.event.entity.EventAppType;
+import com.kt.onrace.domain.event.entity.EventCourse;
+import com.kt.onrace.domain.event.entity.EventPace;
+import com.kt.onrace.domain.event.entity.EventRegion;
+import com.kt.onrace.domain.event.entity.EventStock;
+import com.kt.onrace.domain.event.entity.EventType;
+import com.kt.onrace.domain.event.repository.EventCourseRepository;
+import com.kt.onrace.domain.event.repository.EventPaceRepository;
+import com.kt.onrace.domain.event.repository.EventRepository;
+import com.kt.onrace.domain.event.repository.EventStockRepository;
+import com.kt.onrace.domain.event.service.EventStockService;
+import com.kt.onrace.domain.member.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class EntryServiceTest {
+
+	private static final Long USER_ID = 1L;
+	private static final Long EVENT_ID = 7L;
+	private static final Long COURSE_ID = 15L;
+	private static final Long PACE_ID = 26L;
+
+	@Mock private EntryProperties entryProperties;
+	@Mock private EventRepository eventRepository;
+	@Mock private EventCourseRepository eventCourseRepository;
+	@Mock private EntryRepository entryRepository;
+	@Mock private EventPaceRepository eventPaceRepository;
+	@Mock private MemberRepository memberRepository;
+	@Mock private EventStockService eventStockService;
+	@Mock private EventStockRepository eventStockRepository;
+
+	@InjectMocks
+	private EntryService entryService;
+
+	@Captor
+	private ArgumentCaptor<Entry> entryCaptor;
+
+	// ===== checkStock =====
+
+	@Test
+	@DisplayName("임시 재고가 남아있으면 AVAILABLE을 반환한다")
+	void checkStock_available() {
+		when(eventStockService.getTempStock(PACE_ID)).thenReturn(5L);
+
+		EntryStockCheckResponse response = entryService.checkStock(PACE_ID);
+
+		assertThat(response.stockStatus()).isEqualTo(EntryStockStatus.AVAILABLE);
+		assertThat(response.remainingStock()).isEqualTo(5L);
+	}
+
+	@Test
+	@DisplayName("임시 재고는 없지만 확정 재고가 총 재고 미만이면 TEMP_SOLD_OUT을 반환한다")
+	void checkStock_tempSoldOut() {
+		when(eventStockService.getTempStock(PACE_ID)).thenReturn(0L);
+		when(eventStockService.getTotalStock(PACE_ID)).thenReturn(10L);
+		when(eventStockService.getConfirmStock(PACE_ID)).thenReturn(5L);
+
+		EntryStockCheckResponse response = entryService.checkStock(PACE_ID);
+
+		assertThat(response.stockStatus()).isEqualTo(EntryStockStatus.TEMP_SOLD_OUT);
+		assertThat(response.remainingStock()).isEqualTo(0L);
+	}
+
+	@Test
+	@DisplayName("확정 재고가 총 재고 이상이면 SOLD_OUT을 반환한다")
+	void checkStock_soldOut() {
+		when(eventStockService.getTempStock(PACE_ID)).thenReturn(0L);
+		when(eventStockService.getTotalStock(PACE_ID)).thenReturn(10L);
+		when(eventStockService.getConfirmStock(PACE_ID)).thenReturn(10L);
+
+		EntryStockCheckResponse response = entryService.checkStock(PACE_ID);
+
+		assertThat(response.stockStatus()).isEqualTo(EntryStockStatus.SOLD_OUT);
+		assertThat(response.remainingStock()).isEqualTo(0L);
+	}
+
+	// ===== apply =====
+
+	@Test
+	@DisplayName("응모(LOTTERY) 신청 시 APPLIED 상태의 엔트리가 생성된다")
+	void apply_lotteryCreatesAppliedEntry() {
+		Event event = createEvent(EventAppType.LOTTERY);
+		setId(event, EVENT_ID);
+		EventCourse course = createCourse();
+		EventPace pace = createPace(course);
+		setId(pace, PACE_ID);
+
+		stubCommonApplyDependencies(event, course, pace);
+		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
+		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null);
+
+		verify(entryRepository).save(entryCaptor.capture());
+		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.APPLIED);
+		assertThat(response.status()).isEqualTo(EntryStatus.APPLIED.getDescription());
+	}
+
+	@Test
+	@DisplayName("선착순(FIRST_COME) 신청 성공 시 RESERVED 상태의 엔트리가 생성된다")
+	void apply_firstComeCreatesReservedEntry() {
+		Event event = createEvent(EventAppType.FIRST_COME);
+		setId(event, EVENT_ID);
+		EventCourse course = createCourse();
+		EventPace pace = createPace(course);
+		setId(pace, PACE_ID);
+
+		stubCommonApplyDependencies(event, course, pace);
+		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
+		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(1L);
+		when(entryProperties.getTtlSeconds()).thenReturn(600L);
+		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null);
+
+		verify(entryRepository).save(entryCaptor.capture());
+		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.RESERVED);
+		assertThat(response.status()).isEqualTo(EntryStatus.RESERVED.getDescription());
+		assertThat(response.reservedUntil()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("선착순 신청 시 재고 소진이면 ENTRY_SOLD_OUT 예외가 발생한다")
+	void apply_firstComeSoldOut() {
+		Event event = createEvent(EventAppType.FIRST_COME);
+		setId(event, EVENT_ID);
+		EventCourse course = createCourse();
+		EventPace pace = createPace(course);
+		setId(pace, PACE_ID);
+
+		stubCommonApplyDependencies(event, course, pace);
+		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
+		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(-1L);
+
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+
+		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, null))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.ENTRY_SOLD_OUT);
+	}
+
+	@Test
+	@DisplayName("선착순 신청 시 이미 예약된 사용자면 ENTRY_ALREADY_RESERVED 예외가 발생한다")
+	void apply_firstComeAlreadyReserved() {
+		Event event = createEvent(EventAppType.FIRST_COME);
+		setId(event, EVENT_ID);
+		EventCourse course = createCourse();
+		EventPace pace = createPace(course);
+		setId(pace, PACE_ID);
+
+		stubCommonApplyDependencies(event, course, pace);
+		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
+		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(-2L);
+
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+
+		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, null))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.ENTRY_ALREADY_RESERVED);
+	}
+
+	@Test
+	@DisplayName("대기열 토큰의 paceId와 요청 paceId가 불일치하면 예외가 발생한다")
+	void apply_queuePaceIdMismatch() {
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+		Long wrongQueuePaceId = 99L;
+
+		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, wrongQueuePaceId))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.ENTRY_QUEUE_PACE_MISMATCH);
+	}
+
+	// ===== confirmReservation =====
+
+	@Test
+	@DisplayName("결제 확정 시 엔트리가 APPLIED로 전환되고 Redis 재고가 갱신된다")
+	void confirmReservation_success() {
+		Entry entry = Entry.builder()
+			.userId(USER_ID)
+			.status(EntryStatus.RESERVED)
+			.build();
+		EventStock stock = EventStock.builder()
+			.totalStock(10)
+			.build();
+
+		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.of(entry));
+		when(eventStockService.hasReservation(PACE_ID, USER_ID)).thenReturn(true);
+		when(eventStockRepository.findByEventPaceIdOrThrow(PACE_ID)).thenReturn(stock);
+
+		entryService.confirmReservation(USER_ID, PACE_ID);
+
+		assertThat(entry.getStatus()).isEqualTo(EntryStatus.APPLIED);
+		assertThat(stock.getConfirmedStock()).isEqualTo(1);
+		verify(eventStockService).deleteReservation(PACE_ID, USER_ID);
+		verify(eventStockService).confirmStock(PACE_ID);
+	}
+
+	@Test
+	@DisplayName("결제 확정 시 엔트리가 존재하지 않으면 예외가 발생한다")
+	void confirmReservation_notFound() {
+		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.ENTRY_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("결제 확정 시 엔트리가 RESERVED 상태가 아니면 예외가 발생한다")
+	void confirmReservation_notReserved() {
+		Entry entry = Entry.builder()
+			.userId(USER_ID)
+			.status(EntryStatus.APPLIED)
+			.build();
+
+		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.of(entry));
+
+		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.ENTRY_CANNOT_APPLY);
+	}
+
+	@Test
+	@DisplayName("결제 확정 시 Redis 예약이 만료되었으면 예외가 발생한다")
+	void confirmReservation_reservationExpired() {
+		Entry entry = Entry.builder()
+			.userId(USER_ID)
+			.status(EntryStatus.RESERVED)
+			.build();
+
+		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.of(entry));
+		when(eventStockService.hasReservation(PACE_ID, USER_ID)).thenReturn(false);
+
+		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.ENTRY_RESERVATION_EXPIRED);
+	}
+
+	// ===== helpers =====
+
+	private void stubCommonApplyDependencies(Event event, EventCourse course, EventPace pace) {
+		when(memberRepository.findByIdAndIsDeletedFalseOrThrow(eq(USER_ID), any())).thenReturn(null);
+		when(eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eq(EVENT_ID), any())).thenReturn(event);
+		when(eventCourseRepository.findByIdAndEventIdOrThrow(eq(COURSE_ID), eq(EVENT_ID), any())).thenReturn(course);
+		when(eventPaceRepository.findByIdAndEventCourseIdOrThrow(eq(PACE_ID), eq(COURSE_ID), any())).thenReturn(pace);
+	}
+
+	private Event createEvent(EventAppType appType) {
+		return Event.builder()
+			.title("테스트 이벤트")
+			.type(EventType.MARATHON)
+			.appType(appType)
+			.eventAt(LocalDateTime.now().plusDays(30))
+			.appStartAt(LocalDateTime.now().minusDays(1))
+			.appEndAt(LocalDateTime.now().plusDays(7))
+			.region(EventRegion.SEOUL)
+			.venue("테스트 장소")
+			.isView(true)
+			.soldOut(false)
+			.build();
+	}
+
+	private EventCourse createCourse() {
+		return EventCourse.builder()
+			.name("10km 코스")
+			.courseRoute("테스트 코스 경로")
+			.distanceMeter(10000)
+			.timeLimit(120)
+			.waterSource(3)
+			.altitude(100)
+			.price(25000)
+			.build();
+	}
+
+	private EventPace createPace(EventCourse course) {
+		return EventPace.builder()
+			.eventCourse(course)
+			.name("B그룹")
+			.capacity(10)
+			.build();
+	}
+
+	private void setId(Object target, Long id) {
+		try {
+			Field field = target.getClass().getSuperclass().getDeclaredField("id");
+			field.setAccessible(true);
+			field.set(target, id);
+		} catch (ReflectiveOperationException e) {
+			throw new IllegalStateException(e);
+		}
+	}
+}


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- 신청 시 재고 파악 api 추가(header 응답으로 gateway 캐시에 이벤트 대기열 정보 담아서 반환)
- 대기열 bot filter 추가
- Redis key 및 예약 key 네임스페이스 통일 및 정리(재고 키 분할, 예약키 등 네임스페이스 통일, 불필요 키 제거)
- 응모/선착순 신청 엔드포인트 분리(기존 apply로 사용 시 응모신청도 botfilter 적용되어 응모와 선착순 신청 분리)
- 응모 / 선착순(BotDetection+WaitingRoom) Gateway 라우트 및 필터 적용 분리
- 대기열 토큰 검증 개선(토큰의 paceId와 요청 paceId 교차 검증)
- 재고 조회 응답에 일시 품절 상태 추가

## 📸 스크린샷 / 아키텍처 / 로그 (필수)

- UI 변경 시 스크린샷 첨부 (Frontend 필수)
- 로직 변경 시 관련 로그나 다이어그램, 테스트 결과 캡처 첨부 (Backend/Infra 필수)
- _멘토링 피드백: "글보다 그림/화면으로 소통하세요"_

## ❓ 변경 이유 (Why)
- 기존 단일 재고 카운터로는 "임시 품절 vs 완전 매진" 구분 불가 → 3분할로 정확한 재고 상태 제공
- 응모와 선착순이 같은 엔드포인트를 사용하여 응모에도 불필요한 봇탐지/대기열 필터가 적용됨 → API 분리로 해결
- 대기열 통과 후 다른 페이스로 신청하는 우회 방지를 위해 JWT paceId 교차 검증 필요
- 신청시 apply를 2번 호출해야하는 문제 개선(apply ->VQA -> 대기열 -> apply 구조를 stock 확인 -> VQA -> 대기열 -> apply로 개선)

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
