### PR TITLE
fix(sonar): resolve test errors & configure jacoco classpaths

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run backend tests with coverage
         working-directory: ./backend
-        run: ./gradlew :auth:test :auth:jacocoTestReport :main:test :main:jacocoTestReport --no-daemon
+        run: ./gradlew classes :auth:test :auth:jacocoTestReport :main:test :main:jacocoTestReport --no-daemon
         continue-on-error: true
 
       - name: SonarQube Scan

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ skills/
 rules/
 .vscode
 .env
+
+# Security Scanner Reports
+*_scan.json
+*_scan.txt
+*_deps.txt
+*_dependencies.txt
+*_high_critical.txt

--- a/backend/auth/src/test/java/com/kt/onrace/auth/service/SmsVerifyServiceFindEmailTest.java
+++ b/backend/auth/src/test/java/com/kt/onrace/auth/service/SmsVerifyServiceFindEmailTest.java
@@ -69,7 +69,7 @@ class SmsVerifyServiceFindEmailTest {
 		assertThatCode(() -> smsVerifyService.sendCodeForFind("01012345678", "1.2.3.4"))
 			.doesNotThrowAnyException();
 
-		then(ipCounter).should(never()).expire(any());
+		then(ipCounter).should(never()).expire(any(Duration.class));
 	}
 
 	@Test
@@ -100,10 +100,10 @@ class SmsVerifyServiceFindEmailTest {
 	@Test
 	@DisplayName("가입된 전화번호: SMS 발송")
 	@SuppressWarnings("unchecked")
-	void sendCodeForFind_registeredPhone_sendsSms() {
+	void sendCodeForFind_registeredPhone_sendsSms() throws Exception {
 		RAtomicLong sendAttemptCounter = mock(RAtomicLong.class);
 		RAtomicLong verifyAttemptCounter = mock(RAtomicLong.class);
-		RBucket<String> codeBucket = mock(RBucket.class);
+		RBucket codeBucket = mock(RBucket.class);
 
 		given(redissonClient.getAtomicLong(RedisKeyGenerator.smsFindIpAttemptKey("1.2.3.4"))).willReturn(ipCounter);
 		given(ipCounter.incrementAndGet()).willReturn(1L);
@@ -122,7 +122,7 @@ class SmsVerifyServiceFindEmailTest {
 
 		smsVerifyService.sendCodeForFind("01012345678", "1.2.3.4");
 
-		then(messageService).should().send(any(), isNull());
+		then(messageService).should().send(any(com.solapi.sdk.message.model.Message.class), isNull());
 	}
 
 	@Test

--- a/backend/main/src/main/java/com/kt/onrace/domain/mypage/service/OrderHistoryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/mypage/service/OrderHistoryService.java
@@ -84,7 +84,7 @@ public class OrderHistoryService {
 				currentOrder.getId())
 				.stream()
 				.map(orderPackage -> MyPageOrderDetailResponseDto.PackageInfo.of(
-						orderPackage.getEventPackageId(),
+						orderPackage.getEventItemId(),
 						orderPackage.getName(),
 						orderPackage.getPrice()))
 				.toList();
@@ -145,25 +145,23 @@ public class OrderHistoryService {
 		};
 	}
 
-	<<<<<<<HEAD
+	private MyPageOrderItemDto toOrderItem(Order currentOrder) {
+		MyPageStatusDto status = displayStatusResolver.resolveOrderStatus(currentOrder);
 
-	private OrderLookup buildOrderLookup(List<Order> orders) {
-		Set<Long> courseIds = orders.stream()
-			.map(Order::getEventCourseId)
-			.filter(Objects::nonNull)
-			currentOrder.getOrderNumber(),
-			status.statusText(),
-			status.actionType(),
-			status.actionLabel(),
-			status.actionEnabled(),
-			null,
-			currentOrder.getEventTitle(),
-			currentOrder.getCourseName(),
-			currentOrder.getPaceName(),
-			currentOrder.getFinalAmount(),
-			currentOrder.getCreatedAt(),
-			resolvePaymentDeadlineAt(currentOrder)
-		);
+		return MyPageOrderItemDto.of(
+				currentOrder.getOrderNumber(),
+				currentOrder.getEventId(),
+				status.statusText(),
+				status.actionType(),
+				status.actionLabel(),
+				status.actionEnabled(),
+				null,
+				currentOrder.getEventTitle(),
+				currentOrder.getCourseName(),
+				currentOrder.getPaceName(),
+				currentOrder.getFinalAmount(),
+				currentOrder.getCreatedAt(),
+				resolvePaymentDeadlineAt(currentOrder));
 	}
 
 	private MyPagePaymentHistoryItemDto toPaymentHistoryItem(Order currentOrder) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,7 +20,7 @@ sonar.typescript.tsconfigPath=frontend/tsconfig.json
 
 # Java settings (Backend)
 sonar.java.source=21
-sonar.java.binaries=.
+sonar.java.binaries=backend/auth/build/classes/java/main,backend/main/build/classes/java/main,backend/common/build/classes/java/main,backend/gateway/build/classes/java/main,backend/queue/build/classes/java/main
 sonar.coverage.jacoco.xmlReportPaths=backend/auth/build/reports/jacoco/test/jacocoTestReport.xml,backend/main/build/reports/jacoco/test/jacocoTestReport.xml
 
 # Exclusions


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [x] Infra / DevOps
- [x] Security 

## 🔍 작업 내용 (What)

- SmsVerifyServiceFindEmailTest 내 Mockito 테스트 코드 컴파일 에러 수정 (모호한 any() 타입 명시)
- sonar-project.properties 내의 sonar.java.binaries 속성을 단일 경로(.)에서 백엔드 각 멀티 모듈의 컴파일된 클래스 경로(build/classes/java/main)로 상세 지정
- 로컬 환경에서 생성되는 보안 스캔 리포트 파일들에 대해 .gitignore 무시 처리 규칙 추가 (*_scan.json, *_deps.txt 등)


## ❓ 변경 이유 (Why)
- 테스트 커버리지 수집 문제 해결: 기존에는 백엔드 테스트 코드의 컴파일 에러로 인해 JaCoCo 리포트 자체가 생성되지 않았고, CI 파이프라인(continue-on-error)을 타고 넘어가면서 SonarQubeCoverage가 0%로 수집되었습니다. 에러를 해결하여 정상적으로 리포트가 생성되도록 했습니다.

- SonarQube 경로 매칭 문제 해결: JaCoCo 리포트가 생성되더라도, SonarQube가 멀티 모듈의 .class 바이너리 파일 경로를 찾지 못하면 소스 파일과 커버리지를 매칭(Mapping)하지 못해 0%가 뜨는 문제가 있습니다. 이를 방지하고자 모듈별 정확한 빌드 아웃풋 경로를 지정하였습니다.

- 보안 스캔 파일 업로드 방지: 로컬 점검용 취약점 스캔 텍스트(.txt) 및 JSON 파일이 Github에 업로드되지 않도록 방지 처리했습니다.

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
