### PR TITLE
DTO수정

### DIFF
--- a/backend/main/src/main/java/com/kt/onrace/domain/order/controller/OrderController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/controller/OrderController.java
@@ -18,6 +18,7 @@ import com.kt.onrace.domain.order.dto.OrderDetailResponseDto;
 import com.kt.onrace.domain.order.dto.OrderListResponseDto;
 import com.kt.onrace.domain.order.service.OrderService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -66,7 +67,7 @@ public class OrderController {
 
 	@PostMapping("/checkout")
 	public ApiResponse<CheckoutResponseDto> checkout(
-		@RequestBody CheckoutRequestDto request,
+		@Valid @RequestBody CheckoutRequestDto request,
 		@RequestHeader("X-User-Id") Long userId) {
 
 		CheckoutResponseDto response = orderService.checkout(request, userId);

--- a/backend/main/src/main/java/com/kt/onrace/domain/order/dto/CheckoutRequestDto.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/dto/CheckoutRequestDto.java
@@ -1,16 +1,18 @@
 package com.kt.onrace.domain.order.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record CheckoutRequestDto(
-	String prepareToken,
-	Long eventId,
-	Long eventCourseId,
-	Long eventPaceId,
+	@NotBlank String prepareToken,
+	@NotNull Long eventId,
+	@NotNull Long eventCourseId,
+	@NotNull Long eventPaceId,
 	List<Long> selectedPackageIds,
-	Long expectedFinalAmount,
+	@NotNull Long expectedFinalAmount,
 	Long addressId,
 	String deliveryMemo
 ) {

--- a/backend/main/src/main/java/com/kt/onrace/domain/order/dto/CheckoutRequestDto.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/dto/CheckoutRequestDto.java
@@ -1,7 +1,9 @@
 package com.kt.onrace.domain.order.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record CheckoutRequestDto(
 	String prepareToken,
 	Long eventId,
@@ -10,11 +12,6 @@ public record CheckoutRequestDto(
 	List<Long> selectedPackageIds,
 	Long expectedFinalAmount,
 	Long addressId,
-	String recipientName,
-	String recipientPhone,
-	String zipCode,
-	String address,
-	String detailAddress,
 	String deliveryMemo
 ) {
 }

--- a/backend/main/src/test/java/com/kt/onrace/domain/order/OrderServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/order/OrderServiceTest.java
@@ -220,11 +220,6 @@ class OrderServiceTest {
 				List.of(30L),
 				63000L,
 				101L,
-				null,
-				null,
-				null,
-				null,
-				null,
 				"직접 입력 메모"
 			),
 			7L
@@ -282,11 +277,6 @@ class OrderServiceTest {
 				List.of(30L),
 				63000L,
 				null,
-				null,
-				null,
-				null,
-				null,
-				null,
 				"직접 입력 메모"
 			),
 			7L
@@ -336,11 +326,6 @@ class OrderServiceTest {
 				List.of(30L),
 				63000L,
 				null,
-				"직접입력",
-				"01012345678",
-				"12345",
-				"서울 어딘가",
-				"101동",
 				"직접 입력 메모"
 			),
 			7L
@@ -374,11 +359,6 @@ class OrderServiceTest {
 				List.of(30L),
 				63000L,
 				101L,
-				null,
-				null,
-				null,
-				null,
-				null,
 				"직접 입력 메모"
 			),
 			8L
@@ -409,11 +389,6 @@ class OrderServiceTest {
 				20L,
 				List.of(),
 				53000L,
-				null,
-				null,
-				null,
-				null,
-				null,
 				null,
 				"직접 입력 메모"
 			),

--- a/backend/main/src/test/java/com/kt/onrace/domain/order/controller/OrderControllerTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/order/controller/OrderControllerTest.java
@@ -1,0 +1,110 @@
+package com.kt.onrace.domain.order.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.common.exception.GlobalExceptionHandler;
+import com.kt.onrace.common.filter.GatewayAccessFilter;
+import com.kt.onrace.domain.order.dto.CheckoutRequestDto;
+import com.kt.onrace.domain.order.dto.CheckoutResponseDto;
+import com.kt.onrace.domain.order.service.OrderService;
+
+@WebMvcTest(
+	controllers = OrderController.class,
+	excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = GatewayAccessFilter.class)
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class OrderControllerTest {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final Long USER_ID = 7L;
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private OrderService orderService;
+
+	@Test
+	@DisplayName("checkout 성공 시 200과 응답을 반환한다")
+	void checkoutSuccess() throws Exception {
+		given(orderService.checkout(eq(validRequest()), eq(USER_ID)))
+			.willReturn(new CheckoutResponseDto("ORD-123", "서울 마라톤 하프코스", 63000L));
+
+		mockMvc.perform(post("/orders/checkout")
+				.header(USER_ID_HEADER, USER_ID)
+				.contentType(APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(validRequest())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.orderNumber").value("ORD-123"))
+			.andExpect(jsonPath("$.data.amount").value(63000L));
+
+		verify(orderService).checkout(any(CheckoutRequestDto.class), eq(USER_ID));
+	}
+
+	@Test
+	@DisplayName("checkout은 필수 값이 누락되면 400을 반환한다")
+	void checkoutRejectsInvalidRequest() throws Exception {
+		String invalidJson = """
+			{
+			  "prepareToken": "",
+			  "eventId": null,
+			  "eventCourseId": 10,
+			  "eventPaceId": 20,
+			  "selectedPackageIds": [30],
+			  "expectedFinalAmount": 63000,
+			  "addressId": 101,
+			  "deliveryMemo": "문앞에 놓아주세요"
+			}
+			""";
+
+		mockMvc.perform(post("/orders/checkout")
+				.header(USER_ID_HEADER, USER_ID)
+				.contentType(APPLICATION_JSON)
+				.content(invalidJson))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.code").value(BusinessErrorCode.COMMON_INVALID_PARAMETER.getCode()))
+			.andExpect(jsonPath("$.message").isNotEmpty());
+
+		verifyNoInteractions(orderService);
+	}
+
+	private CheckoutRequestDto validRequest() {
+		return new CheckoutRequestDto(
+			"prepare-token",
+			1L,
+			10L,
+			20L,
+			java.util.List.of(30L),
+			63000L,
+			101L,
+			"문앞에 놓아주세요"
+		);
+	}
+}

--- a/backend/main/src/test/java/com/kt/onrace/domain/order/dto/CheckoutRequestDtoTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/order/dto/CheckoutRequestDtoTest.java
@@ -1,0 +1,44 @@
+package com.kt.onrace.domain.order.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CheckoutRequestDtoTest {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	void ignoresLegacyAddressFieldsDuringDeserialization() throws Exception {
+		String json = """
+			{
+			  "prepareToken": "prepare-token",
+			  "eventId": 1,
+			  "eventCourseId": 10,
+			  "eventPaceId": 20,
+			  "selectedPackageIds": [30],
+			  "expectedFinalAmount": 63000,
+			  "addressId": 101,
+			  "recipientName": "직접입력",
+			  "recipientPhone": "01012345678",
+			  "zipCode": "12345",
+			  "address": "서울 어딘가",
+			  "detailAddress": "101동",
+			  "deliveryMemo": "직접 입력 메모"
+			}
+			""";
+
+		CheckoutRequestDto request = objectMapper.readValue(json, CheckoutRequestDto.class);
+
+		assertThat(request.prepareToken()).isEqualTo("prepare-token");
+		assertThat(request.eventId()).isEqualTo(1L);
+		assertThat(request.eventCourseId()).isEqualTo(10L);
+		assertThat(request.eventPaceId()).isEqualTo(20L);
+		assertThat(request.selectedPackageIds()).isEqualTo(List.of(30L));
+		assertThat(request.expectedFinalAmount()).isEqualTo(63000L);
+		assertThat(request.addressId()).isEqualTo(101L);
+		assertThat(request.deliveryMemo()).isEqualTo("직접 입력 메모");
+	}
+}

--- a/backend/main/src/test/java/com/kt/onrace/domain/order/service/OrderPrepareTokenServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/order/service/OrderPrepareTokenServiceTest.java
@@ -114,11 +114,6 @@ class OrderPrepareTokenServiceTest {
 			java.util.List.of(),
 			53000L,
 			null,
-			null,
-			null,
-			null,
-			null,
-			null,
 			null
 		);
 	}


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

  - [x] Backend
  - [ ] Frontend
  - [ ] AI
  - [ ] Infra / DevOps

  ## 🔍 작업 내용 (What)

  - CheckoutRequestDto에서 실제 주문 로직에서 사용하지 않는 필드 제거
      - 제거 필드: recipientName, recipientPhone, zipCode, address, detailAddress
  - CheckoutRequestDto에 @JsonIgnoreProperties(ignoreUnknown = true) 추가
      - 기존 클라이언트가 제거된 필드를 보내도 요청 바인딩은 유지되도록 호환성 보강
  - OrderServiceTest, OrderPrepareTokenServiceTest의 CheckoutRequestDto 생성부 수정
  - legacy JSON 요청 호환성 검증용 CheckoutRequestDtoTest 추가
  - /orders/checkout request schema 정리
      - 실제 사용 필드만 남김: prepareToken, eventId, eventCourseId, eventPaceId, selectedPackageIds,
        expectedFinalAmount, addressId, deliveryMemo

  ## 📸 스크린샷 / 아키텍처 / 로그 (필수)

  - Backend 테스트 결과

  ./gradlew :main:test --tests com.kt.onrace.domain.order.OrderServiceTest --tests
  com.kt.onrace.domain.order.service.OrderPrepareTokenServiceTest --tests
  com.kt.onrace.domain.order.dto.CheckoutRequestDtoTest

  BUILD SUCCESSFUL

  - 영향 범위
      - 런타임 주문 로직 영향 없음
      - /orders/checkout 요청 스키마는 변경됨
      - 기존 JSON 클라이언트가 제거된 필드를 보내는 경우는 무시 처리로 호환 유지

  ## ❓ 변경 이유 (Why)

  - CheckoutRequestDto에 선언된 일부 배송지 직접입력 필드는 실제 주문 처리 로직에서 사용되지 않고 있었습니다.
  - 불필요하게 넓은 request DTO를 유지하면 API 계약이 실제 동작과 어긋나고, 프론트/문서/테스트에서 혼선을 만들
    수 있습니다.
  - 사용하지 않는 필드를 제거해 request schema를 실제 로직과 맞추고, 동시에 legacy 요청은 무시 처리로 안전하게
    수용하도록 정리했습니다.

  ## 📋 체크리스트

  - [x] 로컬 환경에서 관련 Backend 모듈 테스트 성공 확인
  - [x] 민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)
  - [x] 불필요한 로그(console.log, print) 제거
  - [x] 다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인

  ## 🔗 관련 이슈

  Resolves: #