### PR TITLE
refactor(backend): 신청-재고 관리 구조 리팩토링 및 결제 재고 메소드 제공

### DIFF
--- a/backend/common/src/main/java/com/kt/onrace/common/exception/BusinessErrorCode.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/exception/BusinessErrorCode.java
@@ -87,6 +87,8 @@ public enum BusinessErrorCode implements ErrorCode {
 	ENTRY_ALREADY_RESERVED(HttpStatus.CONFLICT, "ENT_010", "이미 선점한 이벤트입니다."),
 	ENTRY_EVENT_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "ENT_011", "종료된 이벤트입니다."),
 	ENTRY_QUEUE_PACE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_012", "대기열 토큰의 페이스와 신청 페이스가 일치하지 않습니다."),
+	ENTRY_APP_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_013", "해당 이벤트의 신청 방식과 일치하지 않습니다."),
+	ENTRY_CANNOT_CHECKOUT(HttpStatus.BAD_REQUEST, "ENT_014", "결제를 진행할 수 없는 신청 상태입니다"),
 
 	// STOCK
 	STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "STK_001", "재고 정보를 찾을 수 없습니다."),

--- a/backend/common/src/main/java/com/kt/onrace/common/exception/BusinessErrorCode.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/exception/BusinessErrorCode.java
@@ -60,8 +60,8 @@ public enum BusinessErrorCode implements ErrorCode {
 	// EVENT
 	EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "EVT_001", "이벤트를 찾을 수 없습니다."),
 	EVENT_NOT_IN_STANDBY(HttpStatus.BAD_REQUEST, "EVT_002", "사전정보 저장은 대기중 상태에서만 가능합니다."),
-	EVENT_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVT_003", "해당 이벤트의 코스를 찾을 수 없습니다."),
-	EVENT_PACE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVT_004", "해당 코스의 페이스를 찾을 수 없습니다."),
+	EVENT_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVT_003", "이벤트 코스를 찾을 수 없습니다."),
+	EVENT_PACE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVT_004", "이벤트 페이스를 찾을 수 없습니다."),
 	EVENT_PRE_SAVE_NOT_FOUND(HttpStatus.NOT_FOUND, "EVT_005", "사전정보를 찾을 수 없습니다."),
 	EVENT_NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST, "EVT_006", "진행중인 이벤트가 아닙니다."),
 	EVENT_ENDED(HttpStatus.BAD_REQUEST, "EVT_007", "종료된 이벤트입니다."),
@@ -76,18 +76,18 @@ public enum BusinessErrorCode implements ErrorCode {
 
 	// ENTRY
 	ENTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "ENT_001", "신청 정보를 찾을 수 없습니다."),
-	ENTRY_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "ENT_002", "해당 이벤트의 코스를 찾을 수 없습니다."),
-	ENTRY_PACE_NOT_FOUND(HttpStatus.NOT_FOUND, "ENT_003", "해당 코스의 페이스를 찾을 수 없습니다."),
-	ENTRY_EVENT_NOT_IN_STANDBY(HttpStatus.BAD_REQUEST, "ENT_004", "대기중 상태에서만 가능합니다."),
+	ENTRY_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "ENT_002", "이벤트 코스를 찾을 수 없습니다."),
+	ENTRY_PACE_NOT_FOUND(HttpStatus.NOT_FOUND, "ENT_003", "이벤트 페이스를 찾을 수 없습니다."),
+	ENTRY_EVENT_NOT_IN_STANDBY(HttpStatus.BAD_REQUEST, "ENT_004", "신청일 이전에만 가능합니다."),
 	ENTRY_NOT_IN_PERIOD(HttpStatus.BAD_REQUEST, "ENT_005", "신청 기간이 아닙니다."),
 	ENTRY_ALREADY_APPLIED(HttpStatus.BAD_REQUEST, "ENT_006", "이미 신청한 이벤트입니다."),
 	ENTRY_CANNOT_APPLY(HttpStatus.BAD_REQUEST, "ENT_007", "신청할 수 없는 상태입니다."),
 	ENTRY_SOLD_OUT(HttpStatus.CONFLICT, "ENT_008", "신청이 마감되었습니다."),
-	ENTRY_RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "ENT_009", "만료되었습니다. 다시 신청해주세요."),
-	ENTRY_ALREADY_RESERVED(HttpStatus.CONFLICT, "ENT_010", "이미 선점한 이벤트입니다."),
+	ENTRY_RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "ENT_009", "신청이 만료되었습니다. 다시 신청해주세요."),
+	ENTRY_ALREADY_RESERVED(HttpStatus.CONFLICT, "ENT_010", "이미 재고가 예약된 이벤트입니다."),
 	ENTRY_EVENT_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "ENT_011", "종료된 이벤트입니다."),
-	ENTRY_QUEUE_PACE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_012", "대기열 토큰의 페이스와 신청 페이스가 일치하지 않습니다."),
-	ENTRY_APP_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_013", "해당 이벤트의 신청 방식과 일치하지 않습니다."),
+	ENTRY_QUEUE_PACE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_012", "신청 정보가 일치하지 않습니다."), // 대기열 토큰 paceId와 request paceId 불일치
+	ENTRY_APP_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "ENT_013", "신청 정보가 일치하지 않습니다."), // 이벤트의 신청 방식과 일치하지 않습니다.
 	ENTRY_CANNOT_CHECKOUT(HttpStatus.BAD_REQUEST, "ENT_014", "결제를 진행할 수 없는 신청 상태입니다"),
 
 	// STOCK
@@ -107,7 +107,7 @@ public enum BusinessErrorCode implements ErrorCode {
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MBR_001", "회원을 찾을 수 없습니다."),
 
 	// QUEUE
-	QUEUE_NOT_ENABLED(HttpStatus.BAD_REQUEST, "QUE_001", "해당 페이스의 대기열이 활성화되지 않았습니다."),
+	QUEUE_NOT_ENABLED(HttpStatus.BAD_REQUEST, "QUE_001", "대기열이 활성화되지 않았습니다."),
 	QUEUE_ALREADY_ENTERED(HttpStatus.CONFLICT, "QUE_002", "이미 대기열에 진입한 사용자입니다."),
 	QUEUE_NOT_FOUND(HttpStatus.NOT_FOUND, "QUE_003", "대기열에서 사용자를 찾을 수 없습니다."),
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - main-redis-data:/data
     networks:
       - on-race-network
-    command: redis-server --requirepass ${MAIN_REDIS_PASSWORD}
+    command: redis-server --requirepass ${MAIN_REDIS_PASSWORD} --notify-keyspace-events Ex
 
   gateway:
     build:

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/WaitingRoomFilter.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/filter/WaitingRoomFilter.java
@@ -35,6 +35,7 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 
 	private static final String PASS_TOKEN_HEADER = "X-Queue-Token";
 	private static final String QUEUE_PACE_ID_HEADER = "X-Queue-Pace-Id";
+	private static final String USER_ID_HEADER = "X-User-Id";
 	private static final String QUEUE_PASS_TYPE = "QUEUE_PASS";
 	private static final String CLAIM_PACE_ID = "CLAIM_PACE_ID";
 	private static final Pattern EVENT_ID_PATTERN = Pattern.compile("/events/(\\d+)/");
@@ -60,8 +61,9 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 			}
 
 			String passToken = exchange.getRequest().getHeaders().getFirst(PASS_TOKEN_HEADER);
+			String userId = exchange.getRequest().getHeaders().getFirst(USER_ID_HEADER);
 
-			Optional<Long> paceId = extractPaceIdFromToken(passToken);
+			Optional<Long> paceId = extractPaceIdFromToken(passToken, userId);
 			if (paceId.isEmpty()) {
 				return sendQueueRequired(exchange, config);
 			}
@@ -98,8 +100,8 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 		return response.writeWith(Mono.just(buffer));
 	}
 
-	private Optional<Long> extractPaceIdFromToken(String token) {
-		if (token == null) {
+	private Optional<Long> extractPaceIdFromToken(String token, String userId) {
+		if (token == null || userId == null) {
 			return Optional.empty();
 		}
 		try {
@@ -110,6 +112,11 @@ public class WaitingRoomFilter extends AbstractGatewayFilterFactory<WaitingRoomF
 				.getPayload();
 
 			if (!QUEUE_PASS_TYPE.equals(claims.get("type", String.class))) {
+				return Optional.empty();
+			}
+
+			// pass token 소유자와 요청 사용자 일치 검증
+			if (!userId.equals(claims.getSubject())) {
 				return Optional.empty();
 			}
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/controller/EntryController.java
@@ -19,6 +19,7 @@ import com.kt.onrace.domain.entry.dto.EntryPreSaveResponse;
 import com.kt.onrace.domain.entry.dto.EntryRateResponse;
 import com.kt.onrace.domain.entry.dto.EntryStockCheckResponse;
 import com.kt.onrace.domain.entry.service.EntryService;
+import com.kt.onrace.domain.event.entity.EventAppType;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +72,7 @@ public class EntryController {
 		@PathVariable Long eventId,
 		@Valid @RequestBody EntryCoursePaceRequest request
 	) {
-		return ApiResponse.success(entryService.apply(userId, eventId, request, null));
+		return ApiResponse.success(entryService.apply(userId, eventId, request, null, EventAppType.LOTTERY));
 	}
 
 	@PostMapping("/apply/first-come")
@@ -81,24 +82,15 @@ public class EntryController {
 		@PathVariable Long eventId,
 		@Valid @RequestBody EntryCoursePaceRequest request
 	) {
-		return ApiResponse.success(entryService.apply(userId, eventId, request, queuePaceId));
+		return ApiResponse.success(entryService.apply(userId, eventId, request, queuePaceId, EventAppType.FIRST_COME));
 	}
 
 	@GetMapping("/stock-check")
 	public ApiResponse<EntryStockCheckResponse> checkStock(
+		@RequestHeader("X-User-Id") Long userId,
 		@PathVariable Long eventId,
 		@RequestParam Long paceId
-		) {
-		return ApiResponse.success(entryService.checkStock(paceId));
-	}
-
-	// TODO: 결제 API 연동 후 제거 — 테스트용 임시 API입니다 추후에 제가 삭제하겠습니다
-	@PostMapping("/confirm")
-	public ApiResponse<Void> confirmReservation(
-		@RequestHeader("X-User-Id") Long userId,
-		@RequestParam Long paceId
 	) {
-		entryService.confirmReservation(userId, paceId);
-		return ApiResponse.success();
+		return ApiResponse.success(entryService.checkStock(paceId));
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/listener/EntryExpListener.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/listener/EntryExpListener.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
  *   reservation:{paceId}:{userId} 키 TTL 만료
  *   → __keyevent@*__:expired 채널로 알림
  *   → 이 리스너가 수신
- *   → Redis 재고 복원 + DB Entry 정리
+ *   → RESERVED 상태 확인 후 Redis 재고 복원 (Entry는 DB에 유지)
  */
 @Slf4j
 @Component
@@ -35,9 +35,6 @@ public class EntryExpListener {
 	private final EventStockService eventStockService;
 	private final EntryCleanupService entryCleanupService;
 
-	/**
-	 * 앱 시작 완료 후 Redis expired 이벤트 구독을 시작한다.
-	 */
 	@EventListener(ApplicationReadyEvent.class)
 	public void subscribe() {
 		RPatternTopic topic = redissonClient.getPatternTopic(EXPIRATION_PATTERN, StringCodec.INSTANCE);
@@ -57,8 +54,6 @@ public class EntryExpListener {
 				if (cleaned) {
 					eventStockService.restoreStock(paceId);    // RESERVED였을 때만
 				}
-
-				log.info("예약 만료 처리 완료 - paceId: {}, userId: {}", paceId, userId);
 			} catch (Exception e) {
 				log.error("예약 만료 처리 실패 - expiredKey: {}", expiredKey, e);
 			}

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/repository/EntryRepository.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/repository/EntryRepository.java
@@ -10,8 +10,16 @@ import com.kt.onrace.domain.entry.entity.Entry;
 
 public interface EntryRepository extends JpaRepository<Entry, Long>, EntryRepositoryCustom {
 
+	default Entry findByIdOrThrow(Long id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new BusinessException(errorCode));
+	}
+
 	default Entry findByUserIdAndEventIdOrThrow(Long userId, Long eventId, ErrorCode errorCode) {
 		return findByUserIdAndEventId(userId, eventId).orElseThrow(() -> new BusinessException(errorCode));
+	}
+
+	default Entry findByUserIdAndEventPaceIdOrThrow(Long userId, Long eventPaceId, ErrorCode errorCode) {
+		return findByUserIdAndEventPaceId(userId, eventPaceId).orElseThrow(() -> new BusinessException(errorCode));
 	}
 
 	Optional<Entry> findByUserIdAndEventId(Long userId, Long eventId);

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryCleanupService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryCleanupService.java
@@ -10,12 +10,6 @@ import com.kt.onrace.domain.entry.repository.EntryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * TTL 만료 시 RESERVED 상태의 Entry를 정리하는 서비스.
- * ReservationExpirationListener에서 호출되며,
- * 별도 서비스로 분리한 이유: 리스너는 Redisson 콜백 스레드에서 실행되어
- * 자체 @Transactional이 동작하지 않으므로 프록시를 통한 호출이 필요하다.
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,19 +18,10 @@ public class EntryCleanupService {
 
 	private final EntryRepository entryRepository;
 
-	/**
-	 * 만료된 예약의 Entry를 정리한다.
-	 * RESERVED 상태면 삭제, APPLIED 상태면 무시 (결제 완료된 건)
-	 */
 	@ServiceLog
-	@Transactional
 	public boolean cleanupExpiredEntry(Long userId, Long paceId) {
 		return entryRepository.findByUserIdAndEventPaceId(userId, paceId)
 			.filter(Entry::isReserved)
-			.map(entry -> {
-				entryRepository.delete(entry);
-				return true;
-			})
-			.orElse(false);
+			.isPresent();
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
@@ -59,15 +59,22 @@ public class EntryContractService implements OrderEntryContract {
 		entryService.confirmReservation(entry.getUserId(), entry.getEventPace().getId(), appType);
 	}
 
-	// 결제 실패는 재시도 가능하므로 재고선점 시간이 만료되기 전까지 재시도 가능, 환불시에만 호출
 	@Override
 	@Transactional
 	public void rollbackPendingPayment(Long entryId) {
 		Entry entry = entryRepository.findByIdOrThrow(entryId, BusinessErrorCode.ENTRY_NOT_FOUND);
+		EventAppType appType = entry.getEvent().getAppType();
 
-		if(entry.getEvent().getAppType() == EventAppType.FIRST_COME && entry.getStatus() == EntryStatus.APPLIED) {
-			Long paceId = entry.getEventPace().getId();
-			eventStockRepository.findByEventPaceIdOrThrow(paceId).cancelStock();
+		boolean shouldRollback = (appType == EventAppType.FIRST_COME && entry.getStatus() == EntryStatus.APPLIED)
+			|| (appType == EventAppType.LOTTERY && entry.getStatus() == EntryStatus.WON);
+
+		if (!shouldRollback) return;
+
+		Long paceId = entry.getEventPace().getId();
+		eventStockRepository.findByEventPaceIdOrThrow(paceId).cancelStock();
+
+		if (appType == EventAppType.FIRST_COME) {
+			eventStockService.cancelTempStock(paceId);
 			eventStockService.cancelConfirmedStock(paceId);
 		}
 	}

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
@@ -1,18 +1,17 @@
 package com.kt.onrace.domain.entry.service;
 
-import java.time.LocalDateTime;
-import java.util.concurrent.TimeUnit;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.common.util.Preconditions;
 import com.kt.onrace.domain.entry.entity.Entry;
 import com.kt.onrace.domain.entry.entity.EntryStatus;
 import com.kt.onrace.domain.entry.repository.EntryRepository;
 import com.kt.onrace.domain.event.entity.Event;
 import com.kt.onrace.domain.event.entity.EventAppType;
 import com.kt.onrace.domain.event.repository.EventRepository;
+import com.kt.onrace.domain.event.repository.EventStockRepository;
 import com.kt.onrace.domain.event.service.EventStockService;
 import com.kt.onrace.domain.order.contract.OrderCheckoutEligibility;
 import com.kt.onrace.domain.order.contract.OrderEntryContract;
@@ -27,74 +26,49 @@ public class EntryContractService implements OrderEntryContract {
 	private final EntryRepository entryRepository;
 	private final EventRepository eventRepository;
 	private final EventStockService eventStockService;
+	private final EventStockRepository eventStockRepository;
 	private final EntryService entryService;
 
 	@Override
 	public OrderCheckoutEligibility resolveCheckoutEligibility(Long userId, Long eventId, Long paceId) {
-		Event event = eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eventId,
-			BusinessErrorCode.EVENT_NOT_FOUND);
+		Event event = eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eventId, BusinessErrorCode.EVENT_NOT_FOUND);
+		Entry entry = entryRepository.findByUserIdAndEventPaceIdOrThrow(userId, paceId, BusinessErrorCode.ENTRY_NOT_FOUND);
 
-		Entry entry = entryRepository.findByUserIdAndEventIdOrThrow(userId, eventId, BusinessErrorCode.ENTRY_NOT_FOUND);
-
-		EventAppType appType = event.getAppType();
-
-		return switch (appType) {
-			case LOTTERY -> resolveLottery(entry, appType);
-			case FIRST_COME -> resolveFirstCome(entry, appType, paceId, userId);
-		};
-	}
-
-	private OrderCheckoutEligibility resolveLottery(Entry entry, EventAppType appType) {
-		boolean canCheckout = entry.getStatus() == EntryStatus.WON;
-		String failureCode = canCheckout ? null : BusinessErrorCode.ENTRY_CANNOT_APPLY.getCode();
+		boolean canCheckout = event.getAppType() == EventAppType.LOTTERY ?
+			entry.getStatus() == EntryStatus.WON : entry.isReserved() && eventStockService.hasReservation(paceId, userId);
 
 		return OrderCheckoutEligibility.builder()
 			.entryId(entry.getId())
-			.appType(appType)
-			.currentEntryStatus(entry.getStatus())
-			.requiredEntryStatus(EntryStatus.WON)
-			.reservedUntil(null)
-			.requiresReservationValidation(false)
 			.canCheckout(canCheckout)
-			.failureCode(failureCode)
+			.failureCode(canCheckout ? null : BusinessErrorCode.ENTRY_CANNOT_CHECKOUT.getCode())
 			.build();
-	}
-
-	private OrderCheckoutEligibility resolveFirstCome(Entry entry, EventAppType appType, Long paceId, Long userId) {
-		boolean isReserved = entry.isReserved();
-		boolean hasReservation = isReserved && eventStockService.hasReservation(paceId, userId);
-		boolean canCheckout = isReserved && hasReservation;
-
-		LocalDateTime reservedUntil = null;
-		if (canCheckout) {
-			long ttlMs = eventStockService.getReservationTtl(paceId, userId);
-			if (ttlMs > 0) {
-				reservedUntil = LocalDateTime.now().plusNanos(TimeUnit.MILLISECONDS.toNanos(ttlMs));
-			}
-		}
-
-		String failureCode = canCheckout ? null : BusinessErrorCode.ENTRY_RESERVATION_EXPIRED.getCode();
-
-		return OrderCheckoutEligibility.builder()
-			.entryId(entry.getId())
-			.appType(appType)
-			.currentEntryStatus(entry.getStatus())
-			.requiredEntryStatus(EntryStatus.RESERVED)
-			.reservedUntil(reservedUntil)
-			.requiresReservationValidation(true)
-			.canCheckout(canCheckout)
-			.failureCode(failureCode)
-			.build();
-	}
-
-	@Override
-	public boolean hasReservation(Long paceId, Long userId) {
-		return eventStockService.hasReservation(paceId, userId);
 	}
 
 	@Override
 	@Transactional
-	public void confirmReservation(Long userId, Long paceId) {
-		entryService.confirmReservation(userId, paceId);
+	public void handlePaymentConfirmed(Long entryId) {
+		Entry entry = entryRepository.findByIdOrThrow(entryId, BusinessErrorCode.ENTRY_NOT_FOUND);
+		EventAppType appType = entry.getEvent().getAppType();
+
+		if(appType == EventAppType.FIRST_COME) {
+			Preconditions.validate(entry.getStatus() == EntryStatus.RESERVED, BusinessErrorCode.ENTRY_CANNOT_CHECKOUT);
+		} else {
+			Preconditions.validate(entry.getStatus() == EntryStatus.WON, BusinessErrorCode.ENTRY_CANNOT_CHECKOUT);
+		}
+
+		entryService.confirmReservation(entry.getUserId(), entry.getEventPace().getId(), appType);
+	}
+
+	// 결제 실패는 재시도 가능하므로 재고선점 시간이 만료되기 전까지 재시도 가능, 환불시에만 호출
+	@Override
+	@Transactional
+	public void rollbackPendingPayment(Long entryId) {
+		Entry entry = entryRepository.findByIdOrThrow(entryId, BusinessErrorCode.ENTRY_NOT_FOUND);
+
+		if(entry.getEvent().getAppType() == EventAppType.FIRST_COME && entry.getStatus() == EntryStatus.APPLIED) {
+			Long paceId = entry.getEventPace().getId();
+			eventStockRepository.findByEventPaceIdOrThrow(paceId).cancelStock();
+			eventStockService.cancelConfirmedStock(paceId);
+		}
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -1,5 +1,6 @@
 package com.kt.onrace.domain.entry.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -26,7 +27,6 @@ import com.kt.onrace.domain.event.entity.EventAppType;
 import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventStatus;
-import com.kt.onrace.domain.event.entity.EventType;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
@@ -198,6 +198,13 @@ public class EntryService {
 	private EntryApplyResponse applyFirstCome(Long userId, Event event, EventCourse course, EventPace pace) {
 		Entry entry = getCreateEntry(userId, event);
 
+		if (entry.isReserved()) {
+			long remainingMs = eventStockService.getReservationTtl(entry.getEventPace().getId(), userId);
+			if (remainingMs > 0) {
+				return EntryApplyResponse.fromReserved(entry, LocalDateTime.now().plus(Duration.ofMillis(remainingMs)));
+			}
+		}
+
 		long result = eventStockService.tryReserveStock(pace.getId(), userId);
 		Preconditions.validate(result != -2, BusinessErrorCode.ENTRY_ALREADY_RESERVED);
 		Preconditions.validate(result != -1, BusinessErrorCode.ENTRY_SOLD_OUT);
@@ -211,13 +218,9 @@ public class EntryService {
 	private Entry getCreateEntry(Long userId, Event event) {
 		return entryRepository.findByUserIdAndEventId(userId, event.getId())
 				.map(e -> {
-					switch (e.getStatus()) {
-						case APPLIED -> throw new BusinessException(BusinessErrorCode.ENTRY_ALREADY_APPLIED);
-						case RESERVED -> throw new BusinessException(BusinessErrorCode.ENTRY_ALREADY_RESERVED);
-						case PRE_SAVED -> {
-						} // 그대로 반환함
-						default -> throw new BusinessException(BusinessErrorCode.ENTRY_CANNOT_APPLY);
-					}
+					Preconditions.validate(e.getStatus() != EntryStatus.APPLIED, BusinessErrorCode.ENTRY_ALREADY_APPLIED);
+					Preconditions.validate(e.getStatus() == EntryStatus.RESERVED || e.getStatus() == EntryStatus.PRE_SAVED,
+						BusinessErrorCode.ENTRY_CANNOT_APPLY);
 					return e;
 				})
 				.orElseGet(() -> Entry.builder()
@@ -244,25 +247,29 @@ public class EntryService {
 		return EntryStockCheckResponse.tempSoldOut();
 	}
 
-	/**
-	 * 결제 확정 — RESERVED → APPLIED 전환, DB·Redis 확정 재고 증가 및 예약 키 삭제
-	 */
 	@ServiceLog(slowMs = 2000)
 	@Transactional
 	public void confirmReservation(Long userId, Long paceId, EventAppType type) {
 		Entry entry = entryRepository.findByUserIdAndEventPaceId(userId, paceId)
 				.orElseThrow(() -> new BusinessException(BusinessErrorCode.ENTRY_NOT_FOUND));
 
-		Preconditions.validate(entry.isReserved(), BusinessErrorCode.ENTRY_CANNOT_APPLY);
-		Preconditions.validate(eventStockService.hasReservation(paceId, userId),
+
+		if(type == EventAppType.FIRST_COME) {
+			Preconditions.validate(entry.isReserved(), BusinessErrorCode.ENTRY_CANNOT_APPLY);
+			Preconditions.validate(eventStockService.hasReservation(paceId, userId),
 				BusinessErrorCode.ENTRY_RESERVATION_EXPIRED);
 
-		if(type == EventAppType.FIRST_COME)
 			entry.confirmPayment();
+		}
 
 		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
-		eventStockService.deleteReservation(paceId, userId);
-		eventStockService.confirmStock(paceId);
+
+		// 왜? 위의 if로 넣지 않느냐 -> 트랜잭션 커밋이 안된 상태에서 redis는 즉시 실행되고 DB 업데이트는 트랜잭션 커밋 시점에 반영되기
+		// 때문에 DB가 실패할 시 redis는 롤백이 안되므로, DB가 성공적으로 끝난 후 redis를 실행하는 것이 맞음
+		if(type == EventAppType.FIRST_COME) {
+			eventStockService.deleteReservation(paceId, userId);
+			eventStockService.confirmStock(paceId);
+		}
 	}
 
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -22,9 +22,11 @@ import com.kt.onrace.domain.entry.entity.Entry;
 import com.kt.onrace.domain.entry.entity.EntryStatus;
 import com.kt.onrace.domain.entry.repository.EntryRepository;
 import com.kt.onrace.domain.event.entity.Event;
+import com.kt.onrace.domain.event.entity.EventAppType;
 import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventStatus;
+import com.kt.onrace.domain.event.entity.EventType;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
@@ -155,7 +157,8 @@ public class EntryService {
 
 	@ServiceLog(slowMs = 2000)
 	@Transactional
-	public EntryApplyResponse apply(Long userId, Long eventId, EntryCoursePaceRequest request, Long queuePaceId) {
+	public EntryApplyResponse apply(Long userId, Long eventId, EntryCoursePaceRequest request,
+			Long queuePaceId, EventAppType expectedAppType) {
 		if (queuePaceId != null) {
 			Preconditions.validate(queuePaceId.equals(request.paceId()), BusinessErrorCode.ENTRY_QUEUE_PACE_MISMATCH);
 		}
@@ -164,6 +167,8 @@ public class EntryService {
 
 		Event event = eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eventId,
 				BusinessErrorCode.EVENT_NOT_FOUND);
+
+		Preconditions.validate(event.getAppType() == expectedAppType, BusinessErrorCode.ENTRY_APP_TYPE_MISMATCH);
 
 		LocalDateTime now = LocalDateTime.now();
 		Preconditions.validate(event.getEventAt().isAfter(now), BusinessErrorCode.ENTRY_EVENT_ALREADY_ENDED);
@@ -244,7 +249,7 @@ public class EntryService {
 	 */
 	@ServiceLog(slowMs = 2000)
 	@Transactional
-	public void confirmReservation(Long userId, Long paceId) {
+	public void confirmReservation(Long userId, Long paceId, EventAppType type) {
 		Entry entry = entryRepository.findByUserIdAndEventPaceId(userId, paceId)
 				.orElseThrow(() -> new BusinessException(BusinessErrorCode.ENTRY_NOT_FOUND));
 
@@ -252,9 +257,10 @@ public class EntryService {
 		Preconditions.validate(eventStockService.hasReservation(paceId, userId),
 				BusinessErrorCode.ENTRY_RESERVATION_EXPIRED);
 
-		entry.confirmPayment();
-		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
+		if(type == EventAppType.FIRST_COME)
+			entry.confirmPayment();
 
+		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
 		eventStockService.deleteReservation(paceId, userId);
 		eventStockService.confirmStock(paceId);
 	}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/entity/EventStock.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/entity/EventStock.java
@@ -51,6 +51,10 @@ public class EventStock extends BaseEntity {
 		this.confirmedStock++;
 	}
 
+	public void cancelStock() {
+		this.confirmedStock--;
+	}
+
 	public int getAvailableStock() {
 		return this.totalStock - this.confirmedStock;
 	}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -74,8 +74,7 @@ public class EventStockService {
 	}
 
 	public void restoreStock(Long paceId) {
-		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId));
-		stock.incrementAndGet();
+		redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId)).incrementAndGet();
 	}
 
 	public boolean hasReservation(Long paceId, Long userId) {
@@ -97,6 +96,9 @@ public class EventStockService {
 
 	public void cancelConfirmedStock(Long paceId) {
 		redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId)).decrementAndGet();
+	}
+
+	public void cancelTempStock(Long paceId) {
 		redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId)).incrementAndGet();
 	}
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -95,4 +95,9 @@ public class EventStockService {
 		stock.incrementAndGet();
 	}
 
+	public void cancelConfirmedStock(Long paceId) {
+		redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId)).decrementAndGet();
+		redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId)).incrementAndGet();
+	}
+
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderCheckoutEligibility.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderCheckoutEligibility.java
@@ -15,11 +15,6 @@ import lombok.Builder;
 @Builder
 public record OrderCheckoutEligibility(
 	Long entryId,
-	EventAppType appType,
-	EntryStatus currentEntryStatus,
-	EntryStatus requiredEntryStatus,
-	LocalDateTime reservedUntil,
-	boolean requiresReservationValidation,
 	boolean canCheckout,
 	String failureCode
 ) {

--- a/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderEntryContract.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/order/contract/OrderEntryContract.java
@@ -8,10 +8,6 @@ public interface OrderEntryContract {
 
 	OrderCheckoutEligibility resolveCheckoutEligibility(Long userId, Long eventId, Long paceId);
 
-	boolean hasReservation(Long paceId, Long userId);
-
-	void confirmReservation(Long userId, Long paceId);
-
 	default void handlePaymentConfirmed(Long entryId) {
 		// order 티켓 단계에서는 계약만 열어두고 실제 구현은 후속 작업에서 연결한다.
 	}

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/controller/EntryControllerTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/controller/EntryControllerTest.java
@@ -4,7 +4,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -32,6 +31,7 @@ import com.kt.onrace.domain.entry.dto.EntryApplyResponse;
 import com.kt.onrace.domain.entry.dto.EntryCoursePaceRequest;
 import com.kt.onrace.domain.entry.dto.EntryStockCheckResponse;
 import com.kt.onrace.domain.entry.service.EntryService;
+import com.kt.onrace.domain.event.entity.EventAppType;
 
 @WebMvcTest(
 	controllers = EntryController.class,
@@ -60,7 +60,7 @@ class EntryControllerTest {
 	@DisplayName("응모 신청 성공 시 200과 엔트리 응답을 반환한다")
 	void applyLottery_success() throws Exception {
 		EntryApplyResponse response = new EntryApplyResponse(1L, EVENT_ID, "신청완료", null, null, null);
-		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull()))
+		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull(), eq(EventAppType.LOTTERY)))
 			.willReturn(response);
 
 		mockMvc.perform(post("/events/{eventId}/entries/apply/lottery", EVENT_ID)
@@ -72,7 +72,7 @@ class EntryControllerTest {
 			.andExpect(jsonPath("$.data.entryId").value(1L))
 			.andExpect(jsonPath("$.data.status").value("신청완료"));
 
-		verify(entryService).apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull());
+		verify(entryService).apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull(), eq(EventAppType.LOTTERY));
 	}
 
 	@Test
@@ -80,7 +80,7 @@ class EntryControllerTest {
 	void applyFirstCome_success() throws Exception {
 		LocalDateTime reservedUntil = LocalDateTime.of(2026, 4, 1, 12, 10, 0);
 		EntryApplyResponse response = new EntryApplyResponse(1L, EVENT_ID, "선점완료", reservedUntil, null, null);
-		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull()))
+		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), isNull(), eq(EventAppType.FIRST_COME)))
 			.willReturn(response);
 
 		mockMvc.perform(post("/events/{eventId}/entries/apply/first-come", EVENT_ID)
@@ -97,7 +97,7 @@ class EntryControllerTest {
 	@DisplayName("선착순 신청 시 X-Queue-Pace-Id 헤더가 서비스에 전달된다")
 	void applyFirstCome_withQueuePaceId() throws Exception {
 		EntryApplyResponse response = new EntryApplyResponse(1L, EVENT_ID, "선점완료", null, null, null);
-		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), eq(PACE_ID)))
+		given(entryService.apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), eq(PACE_ID), eq(EventAppType.FIRST_COME)))
 			.willReturn(response);
 
 		mockMvc.perform(post("/events/{eventId}/entries/apply/first-come", EVENT_ID)
@@ -108,7 +108,7 @@ class EntryControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true));
 
-		verify(entryService).apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), eq(PACE_ID));
+		verify(entryService).apply(eq(USER_ID), eq(EVENT_ID), any(EntryCoursePaceRequest.class), eq(PACE_ID), eq(EventAppType.FIRST_COME));
 	}
 
 	@Test
@@ -117,6 +117,7 @@ class EntryControllerTest {
 		given(entryService.checkStock(PACE_ID)).willReturn(EntryStockCheckResponse.available(5));
 
 		mockMvc.perform(get("/events/{eventId}/entries/stock-check", EVENT_ID)
+				.header(USER_ID_HEADER, USER_ID)
 				.param("paceId", String.valueOf(PACE_ID)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.success").value(true))
@@ -124,17 +125,4 @@ class EntryControllerTest {
 			.andExpect(jsonPath("$.data.remainingStock").value(5));
 	}
 
-	@Test
-	@DisplayName("결제 확정 성공 시 200을 반환한다")
-	void confirmReservation_success() throws Exception {
-		doNothing().when(entryService).confirmReservation(USER_ID, PACE_ID);
-
-		mockMvc.perform(post("/events/{eventId}/entries/confirm", EVENT_ID)
-				.header(USER_ID_HEADER, USER_ID)
-				.param("paceId", String.valueOf(PACE_ID)))
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.success").value(true));
-
-		verify(entryService).confirmReservation(USER_ID, PACE_ID);
-	}
 }

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
@@ -122,7 +122,7 @@ class EntryServiceTest {
 		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
-		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null);
+		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.LOTTERY);
 
 		verify(entryRepository).save(entryCaptor.capture());
 		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.APPLIED);
@@ -145,7 +145,7 @@ class EntryServiceTest {
 		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
-		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null);
+		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME);
 
 		verify(entryRepository).save(entryCaptor.capture());
 		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.RESERVED);
@@ -168,7 +168,7 @@ class EntryServiceTest {
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 
-		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, null))
+		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_SOLD_OUT);
@@ -189,7 +189,7 @@ class EntryServiceTest {
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 
-		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, null))
+		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_ALREADY_RESERVED);
@@ -201,7 +201,7 @@ class EntryServiceTest {
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 		Long wrongQueuePaceId = 99L;
 
-		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, wrongQueuePaceId))
+		assertThatThrownBy(() -> entryService.apply(USER_ID, EVENT_ID, request, wrongQueuePaceId, EventAppType.FIRST_COME))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_QUEUE_PACE_MISMATCH);
@@ -224,7 +224,7 @@ class EntryServiceTest {
 		when(eventStockService.hasReservation(PACE_ID, USER_ID)).thenReturn(true);
 		when(eventStockRepository.findByEventPaceIdOrThrow(PACE_ID)).thenReturn(stock);
 
-		entryService.confirmReservation(USER_ID, PACE_ID);
+		entryService.confirmReservation(USER_ID, PACE_ID, EventAppType.FIRST_COME);
 
 		assertThat(entry.getStatus()).isEqualTo(EntryStatus.APPLIED);
 		assertThat(stock.getConfirmedStock()).isEqualTo(1);
@@ -237,7 +237,7 @@ class EntryServiceTest {
 	void confirmReservation_notFound() {
 		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID))
+		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID, EventAppType.FIRST_COME))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_NOT_FOUND);
@@ -253,7 +253,7 @@ class EntryServiceTest {
 
 		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.of(entry));
 
-		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID))
+		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID, EventAppType.FIRST_COME))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_CANNOT_APPLY);
@@ -270,7 +270,7 @@ class EntryServiceTest {
 		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.of(entry));
 		when(eventStockService.hasReservation(PACE_ID, USER_ID)).thenReturn(false);
 
-		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID))
+		assertThatThrownBy(() -> entryService.confirmReservation(USER_ID, PACE_ID, EventAppType.FIRST_COME))
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_RESERVATION_EXPIRED);

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -193,6 +194,70 @@ class EntryServiceTest {
 			.isInstanceOf(BusinessException.class)
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.ENTRY_ALREADY_RESERVED);
+	}
+
+	@Test
+	@DisplayName("선착순 신청 시 DB에 RESERVED 엔트리가 있고 Redis 예약이 활성이면 기존 예약 정보를 반환한다")
+	void apply_firstComeReservedWithActiveReservation() {
+		Event event = createEvent(EventAppType.FIRST_COME);
+		setId(event, EVENT_ID);
+		EventCourse course = createCourse();
+		EventPace pace = createPace(course);
+		setId(pace, PACE_ID);
+
+		Entry existingEntry = Entry.builder()
+			.userId(USER_ID)
+			.event(event)
+			.eventCourse(course)
+			.eventPace(pace)
+			.status(EntryStatus.RESERVED)
+			.build();
+
+		stubCommonApplyDependencies(event, course, pace);
+		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID))
+			.thenReturn(Optional.of(existingEntry));
+		when(eventStockService.getReservationTtl(PACE_ID, USER_ID)).thenReturn(300_000L);
+
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME);
+
+		assertThat(response.status()).isEqualTo(EntryStatus.RESERVED.getDescription());
+		assertThat(response.reservedUntil()).isNotNull();
+		verify(eventStockService, never()).tryReserveStock(any(), any());
+	}
+
+	@Test
+	@DisplayName("선착순 신청 시 DB에 RESERVED 엔트리가 있지만 Redis 예약이 만료되었으면 재신청에 성공한다")
+	void apply_firstComeReservedWithExpiredReservation() {
+		Event event = createEvent(EventAppType.FIRST_COME);
+		setId(event, EVENT_ID);
+		EventCourse course = createCourse();
+		EventPace pace = createPace(course);
+		setId(pace, PACE_ID);
+
+		Entry existingEntry = Entry.builder()
+			.userId(USER_ID)
+			.event(event)
+			.eventCourse(course)
+			.eventPace(pace)
+			.status(EntryStatus.RESERVED)
+			.build();
+
+		stubCommonApplyDependencies(event, course, pace);
+		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID))
+			.thenReturn(Optional.of(existingEntry));
+		when(eventStockService.getReservationTtl(PACE_ID, USER_ID)).thenReturn(-2L);
+		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(1L);
+		when(entryProperties.getTtlSeconds()).thenReturn(600L);
+		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
+
+		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
+		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME);
+
+		verify(entryRepository).save(entryCaptor.capture());
+		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.RESERVED);
+		assertThat(response.status()).isEqualTo(EntryStatus.RESERVED.getDescription());
+		assertThat(response.reservedUntil()).isNotNull();
 	}
 
 	@Test

--- a/backend/main/src/test/java/com/kt/onrace/domain/order/OrderServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/order/OrderServiceTest.java
@@ -687,10 +687,6 @@ class OrderServiceTest {
 		when(orderEntryContract.resolveCheckoutEligibility(eq(userId), eq(1L), eq(20L)))
 			.thenReturn(OrderCheckoutEligibility.builder()
 				.entryId(1000L)
-				.appType(EventAppType.LOTTERY)
-				.currentEntryStatus(com.kt.onrace.domain.entry.entity.EntryStatus.WON)
-				.requiredEntryStatus(com.kt.onrace.domain.entry.entity.EntryStatus.WON)
-				.requiresReservationValidation(false)
 				.canCheckout(canCheckout)
 				.failureCode(failureCode)
 				.build());


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- EntryContractService 리팩토링: 메소드 정리
  - resolveCheckoutEligibility : 결제 가능 여부 판단 (응모→WON, 선착순→RESERVED+예약키)
  - handlePaymentConfirmed : 결제 확정 시 재고 확정 처리
  - rollbackPendingPayment : 환불 시 확정 재고 롤백 (결제 실패는 TTL 만료로 자동 정리)
- OrderEntryContract 인터페이스 정리: 불필요한 위임 메서드 제거 (hasReservation, confirmReservation)
- OrderCheckoutEligibility 필드 간소화: entryId, canCheckout, failureCode만 유지
- apply()에 EventAppType 검증 추가: 응모 엔드포인트로 선착순 신청 등 방지
- confirmReservation에 EventAppType 파라미터 추가: 응모는 WON 유지, 선착순만 APPLIED 전환
- EventStock.cancelStock() + EventStockService.cancelConfirmedStock() 추가: 환불 시 DB/Redis 재고 복원
- docker-compose Redis에 --notify-keyspace-events Ex 설정 추가: TTL 만료 리스너 자동 활성화
- 임시 테스트용 confirm API 제거, checkStock 엔드포인트에 X-User-Id 헤더 추가

## 📸 스크린샷 / 아키텍처 / 로그 (필수)
|      시나리오   |    임시재고    |      확정재고    |       Entry 상태       |
|     신청 (Lua)  |        -1          |          0           |       RESERVED       |
|     결제 확정   |      유지         |       +1           |        APPLIED          |
|     결제 실패   |      유지         |         0           |        RESERVED       |  -> 재고 TTL 만료 시 redis event 실행 재고 복구 및 KEY 삭제
|        환불        |      +1           |        -1           |      APPLIED 유지    |


## ❓ 변경 이유 (Why)
- 기존 EntryContractService에 불필요한 위임 메서드와 중복 로직이 많아 주문/결제팀과의 계약 인터페이스를 최소화
- 결제 실패 시 재고 선점을 즉시 해제하지 않고 TTL 만료까지 재결제 가능하도록 정책 반영
- 환불 시 확정 재고를 복원하는 rollback 메커니즘 추가
- Redis keyspace notification 설정을 docker-compose에 포함하여 운영 환경 자동화

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
