### PR TITLE
feat(backend): 회원가입 name 옵션화 및 PASS 본인인증 완료/해제 API 추가

### DIFF
--- a/backend/auth/src/main/java/com/kt/onrace/auth/controller/AccountController.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/controller/AccountController.java
@@ -1,5 +1,6 @@
 package com.kt.onrace.auth.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.onrace.auth.dto.AccountMeResponse;
+import com.kt.onrace.auth.dto.PassVerificationCompleteRequest;
 import com.kt.onrace.auth.dto.PasswordChangeRequest;
 import com.kt.onrace.auth.dto.UpdateMarketingConsentRequest;
 import com.kt.onrace.auth.dto.UpdateNameRequest;
@@ -67,6 +69,25 @@ public class AccountController extends SwaggerAssistance {
 		@Valid @RequestBody PasswordChangeRequest request) {
 
 		accountService.requestPasswordChange(userId, request.currentPassword());
+		return ApiResponse.success();
+	}
+
+	@Operation(summary = "PASS 본인인증 완료", description = "PASS 인증 후 이름, 성별, 생년월일을 저장하고 인증 상태를 VERIFIED로 변경")
+	@PostMapping("/pass/complete")
+	public ApiResponse<Void> completePassVerification(
+		@RequestHeader("X-User-Id") Long userId,
+		@Valid @RequestBody PassVerificationCompleteRequest request) {
+
+		accountService.completePassVerification(userId, request.name(), request.gender(), request.birthdate());
+		return ApiResponse.success();
+	}
+
+	@Operation(summary = "PASS 본인인증 해제", description = "인증 상태를 UNVERIFIED로 되돌림")
+	@DeleteMapping("/pass/complete")
+	public ApiResponse<Void> revokePassVerification(
+		@RequestHeader("X-User-Id") Long userId) {
+
+		accountService.revokePassVerification(userId);
 		return ApiResponse.success();
 	}
 }

--- a/backend/auth/src/main/java/com/kt/onrace/auth/dto/PassVerificationCompleteRequest.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/dto/PassVerificationCompleteRequest.java
@@ -1,0 +1,18 @@
+package com.kt.onrace.auth.dto;
+
+import java.time.LocalDate;
+
+import com.kt.onrace.auth.entity.Gender;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PassVerificationCompleteRequest(
+	@NotBlank(message = "이름을 입력해 주세요.") @Size(max = 50, message = "이름은 50자 이하이어야 합니다.") String name,
+
+	@NotNull(message = "성별을 입력해 주세요.") Gender gender,
+
+	@NotNull(message = "생년월일을 입력해 주세요.") LocalDate birthdate
+) {
+}

--- a/backend/auth/src/main/java/com/kt/onrace/auth/dto/SignupRequest.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/dto/SignupRequest.java
@@ -1,7 +1,9 @@
 package com.kt.onrace.auth.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import com.kt.onrace.auth.entity.Gender;
 import com.kt.onrace.common.logging.annotation.SensitiveLog;
 
 import jakarta.validation.Valid;
@@ -15,7 +17,11 @@ import jakarta.validation.constraints.Size;
 public record SignupRequest(
 		@NotBlank(message = "이메일을 입력해 주세요.") @Email(message = "올바른 이메일 형식이 아닙니다.") @Size(max = 100) String email,
 
-		@NotBlank(message = "이름을 입력해 주세요.") @Size(max = 50, message = "이름은 50자 이하이어야 합니다.") String name,
+		@Size(max = 50, message = "이름은 50자 이하이어야 합니다.") String name,
+
+		Gender gender,
+
+		LocalDate birthdate,
 
 		@NotBlank(message = "비밀번호를 입력해 주세요.") @Pattern(regexp = "^(?:(?=.*[a-zA-Z])(?=.*\\d)|(?=.*[a-zA-Z])(?=.*[!@#$%^&*])|(?=.*\\d)(?=.*[!@#$%^&*]))[A-Za-z\\d!@#$%^&*]{10,16}$", message = "비밀번호는 10~16자이며, 영문/숫자/특수문자(!@#$%^&*) 중 2가지 이상 조합이어야 합니다.") String password,
 

--- a/backend/auth/src/main/java/com/kt/onrace/auth/entity/Gender.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.kt.onrace.auth.entity;
+
+public enum Gender {
+	MALE, FEMALE
+}

--- a/backend/auth/src/main/java/com/kt/onrace/auth/entity/User.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/entity/User.java
@@ -3,6 +3,8 @@ package com.kt.onrace.auth.entity;
 import static com.kt.onrace.auth.entity.Role.*;
 import static com.kt.onrace.auth.entity.UserStatus.*;
 
+import java.time.LocalDate;
+
 import com.kt.onrace.common.entity.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -21,8 +23,15 @@ public class User extends BaseEntity {
 	@Column(nullable = false, length = 100)
 	private String email;
 
-	@Column(nullable = false, length = 50)
+	@Column(length = 50)
 	private String name;
+
+	@Enumerated(EnumType.STRING)
+	@Column(length = 10)
+	private Gender gender;
+
+	@Column
+	private LocalDate birthdate;
 
 	// OAuth 사용자는 전화번호 없이 가입 가능
 	@Column(length = 20)
@@ -58,11 +67,13 @@ public class User extends BaseEntity {
 	@Column(nullable = false, columnDefinition = "TINYINT(1) NOT NULL DEFAULT 0")
 	private boolean marketingConsent = false;
 
-	private User(String email, String name, String password, String phoneNumber) {
+	private User(String email, String name, String password, String phoneNumber, Gender gender, LocalDate birthdate) {
 		this.email = email;
 		this.name = name;
 		this.password = password;
 		this.phoneNumber = phoneNumber;
+		this.gender = gender;
+		this.birthdate = birthdate;
 		this.authProvider = AuthProvider.LOCAL;
 		this.role = USER;
 		this.status = ACTIVE;
@@ -77,8 +88,8 @@ public class User extends BaseEntity {
 		this.status = ACTIVE;
 	}
 
-	public static User createUser(String email, String name, String password, String phoneNumber) {
-		return new User(email, name, password, phoneNumber);
+	public static User createUser(String email, String name, String password, String phoneNumber, Gender gender, LocalDate birthdate) {
+		return new User(email, name, password, phoneNumber, gender, birthdate);
 	}
 
 	public static User createOAuthUser(String email, String name, AuthProvider authProvider, String providerId) {
@@ -111,6 +122,13 @@ public class User extends BaseEntity {
 
 	public void changeVerificationStatus(VerificationStatus verificationStatus) {
 		this.verificationStatus = verificationStatus;
+	}
+
+	public void applyPassVerification(String name, Gender gender, LocalDate birthdate) {
+		this.name = name;
+		this.gender = gender;
+		this.birthdate = birthdate;
+		this.verificationStatus = VerificationStatus.VERIFIED;
 	}
 
 	public boolean canChangePassword() {

--- a/backend/auth/src/main/java/com/kt/onrace/auth/service/AccountService.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/service/AccountService.java
@@ -1,5 +1,7 @@
 package com.kt.onrace.auth.service;
 
+import java.time.LocalDate;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kt.onrace.auth.config.AppProperties;
 import com.kt.onrace.auth.dto.AccountMeResponse;
 import com.kt.onrace.auth.entity.AuthProvider;
+import com.kt.onrace.auth.entity.Gender;
 import com.kt.onrace.auth.entity.User;
 import com.kt.onrace.auth.entity.VerificationStatus;
 import com.kt.onrace.auth.repository.UserRepository;
@@ -63,6 +66,18 @@ public class AccountService {
 	public void updateMarketingConsent(Long userId, boolean marketingConsent) {
 		User user = findActiveUser(userId);
 		user.changeMarketingConsent(marketingConsent);
+	}
+
+	@Transactional
+	public void completePassVerification(Long userId, String name, Gender gender, LocalDate birthdate) {
+		User user = findActiveUser(userId);
+		user.applyPassVerification(name, gender, birthdate);
+	}
+
+	@Transactional
+	public void revokePassVerification(Long userId) {
+		User user = findActiveUser(userId);
+		user.changeVerificationStatus(VerificationStatus.UNVERIFIED);
 	}
 
 	private User findActiveUser(Long userId) {

--- a/backend/auth/src/main/java/com/kt/onrace/auth/service/AuthService.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/service/AuthService.java
@@ -109,7 +109,9 @@ public class AuthService {
 				request.email(),
 				request.name(),
 				encodedPassword,
-				request.phoneNumber());
+				request.phoneNumber(),
+				request.gender(),
+				request.birthdate());
 
 		User saved = userRepository.save(user);
 

--- a/backend/auth/src/test/java/com/kt/onrace/auth/service/AccountServicePassVerificationTest.java
+++ b/backend/auth/src/test/java/com/kt/onrace/auth/service/AccountServicePassVerificationTest.java
@@ -1,0 +1,108 @@
+package com.kt.onrace.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.kt.onrace.auth.config.AppProperties;
+import com.kt.onrace.auth.entity.Gender;
+import com.kt.onrace.auth.entity.User;
+import com.kt.onrace.auth.entity.VerificationStatus;
+import com.kt.onrace.auth.repository.UserRepository;
+import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.common.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServicePassVerificationTest {
+
+	@InjectMocks
+	private AccountService accountService;
+
+	@Mock
+	private AppProperties appProperties;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private PasswordResetService passwordResetService;
+
+	private static final Long USER_ID = 1L;
+	private static final String NAME = "홍길동";
+	private static final Gender GENDER = Gender.MALE;
+	private static final LocalDate BIRTHDATE = LocalDate.of(1995, 3, 15);
+
+	private User activeUser;
+
+	@BeforeEach
+	void setUp() {
+		activeUser = User.createUser("test@test.com", null, "encodedPw", "01012345678", null, null);
+		ReflectionTestUtils.setField(activeUser, "id", USER_ID);
+	}
+
+	// ── completePassVerification ──────────────────────────────────────────────
+
+	@Test
+	@DisplayName("PASS 인증 완료 성공: name/gender/birthdate 저장, verificationStatus → VERIFIED")
+	void completePassVerification_success() {
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(activeUser));
+
+		accountService.completePassVerification(USER_ID, NAME, GENDER, BIRTHDATE);
+
+		assertThat(activeUser.getName()).isEqualTo(NAME);
+		assertThat(activeUser.getGender()).isEqualTo(GENDER);
+		assertThat(activeUser.getBirthdate()).isEqualTo(BIRTHDATE);
+		assertThat(activeUser.getVerificationStatus()).isEqualTo(VerificationStatus.VERIFIED);
+	}
+
+	@Test
+	@DisplayName("PASS 인증 완료 실패: 존재하지 않는 유저 → AUTH_NOT_FOUND_USER")
+	void completePassVerification_userNotFound() {
+		given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> accountService.completePassVerification(USER_ID, NAME, GENDER, BIRTHDATE))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException) e).getErrorCode())
+			.isEqualTo(BusinessErrorCode.AUTH_NOT_FOUND_USER);
+	}
+
+	// ── revokePassVerification ────────────────────────────────────────────────
+
+	@Test
+	@DisplayName("PASS 인증 해제 성공: verificationStatus → UNVERIFIED")
+	void revokePassVerification_success() {
+		// 먼저 VERIFIED 상태로 만들기
+		activeUser.applyPassVerification(NAME, GENDER, BIRTHDATE);
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(activeUser));
+
+		accountService.revokePassVerification(USER_ID);
+
+		assertThat(activeUser.getVerificationStatus()).isEqualTo(VerificationStatus.UNVERIFIED);
+	}
+
+	@Test
+	@DisplayName("PASS 인증 해제 실패: 존재하지 않는 유저 → AUTH_NOT_FOUND_USER")
+	void revokePassVerification_userNotFound() {
+		given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+		assertThatThrownBy(() -> accountService.revokePassVerification(USER_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting(e -> ((BusinessException) e).getErrorCode())
+			.isEqualTo(BusinessErrorCode.AUTH_NOT_FOUND_USER);
+	}
+}

--- a/backend/auth/src/test/java/com/kt/onrace/auth/service/AuthServiceLoginTest.java
+++ b/backend/auth/src/test/java/com/kt/onrace/auth/service/AuthServiceLoginTest.java
@@ -82,7 +82,7 @@ class AuthServiceLoginTest {
 
 	@BeforeEach
 	void setUp() {
-		testUser = User.createUser("test@test.com", "테스터", "encodedPw", "01012345678");
+		testUser = User.createUser("test@test.com", "테스터", "encodedPw", "01012345678", null, null);
 		ReflectionTestUtils.setField(testUser, "id", 1L);
 	}
 

--- a/backend/auth/src/test/java/com/kt/onrace/auth/service/AuthServiceLogoutWithdrawTest.java
+++ b/backend/auth/src/test/java/com/kt/onrace/auth/service/AuthServiceLogoutWithdrawTest.java
@@ -83,7 +83,7 @@ class AuthServiceLogoutWithdrawTest {
 
 	@BeforeEach
 	void setUp() {
-		testUser = User.createUser("test@test.com", "테스터", "encodedPw", "01012345678");
+		testUser = User.createUser("test@test.com", "테스터", "encodedPw", "01012345678", null, null);
 		ReflectionTestUtils.setField(testUser, "id", 1L);
 	}
 

--- a/backend/auth/src/test/java/com/kt/onrace/auth/service/AuthServiceSignupTest.java
+++ b/backend/auth/src/test/java/com/kt/onrace/auth/service/AuthServiceSignupTest.java
@@ -103,7 +103,7 @@ class AuthServiceSignupTest {
 	}
 
 	private SignupRequest buildRequest(List<TermAgreement> agreements) {
-		return new SignupRequest(EMAIL, NAME, PASSWORD, PHONE, agreements);
+		return new SignupRequest(EMAIL, NAME, null, null, PASSWORD, PHONE, agreements);
 	}
 
 	// ── isVerified 단계 실패 ─────────────────────────────────────────────────
@@ -195,7 +195,7 @@ class AuthServiceSignupTest {
 	@Test
 	@DisplayName("회원가입 성공: 검증 통과 후 consumeVerification 호출, 사용자 저장, 약관 동의 기록")
 	void signup_success() {
-		User savedUser = User.createUser(EMAIL, NAME, "encodedPw", PHONE);
+		User savedUser = User.createUser(EMAIL, NAME, "encodedPw", PHONE, null, null);
 		ReflectionTestUtils.setField(savedUser, "id", 1L);
 
 		given(emailVerifyService.isVerified(EMAIL)).willReturn(true);


### PR DESCRIPTION
🎯 작업 타겟 (Monorepo)

  - Backend

  🔍 작업 내용 (What)

  - SignupRequest.name 필수 → 옵션으로 변경
  - SignupRequest에 gender, birthdate 옵션 필드 추가
  - User 엔티티에 gender, birthdate 컬럼 추가 / name nullable 변경
  - POST /account/pass/complete API 추가 — PASS 인증 완료 후 이름·성별·생년월일 저장 및 verificationStatus →
  VERIFIED
  - DELETE /account/pass/complete API 추가 — 본인인증 상태 UNVERIFIED 복구
  - 영향받은 단위 테스트 3개 수정 (User.createUser() 시그니처 변경 대응)

  📸 스크린샷 / 아키텍처 / 로그 (필수)

  POST /account/pass/complete
  {
    "name": "홍길동",
    "gender": "MALE",
    "birthdate": "1995-03-15"
  }
  → 200 OK

  DELETE /account/pass/complete
  → 200 OK

  ❓ 변경 이유 (Why)

  PASS 본인인증(건너뛰기 가능) 플로우 도입으로 인해 회원가입 시 이름·성별·생년월일이 필수가 아니게 됨.
  인증 완료 후 별도 API를 통해 해당 정보를 저장하는 구조로 변경. 프론트엔드는 현재 목업으로 진행 중.

  📋 체크리스트

  - 로컬 환경에서 빌드 및 테스트 성공 확인
  - 민감 정보 하드코딩 없음
  - 불필요한 로그 없음
  - 프론트 영향 확인 — signup API name 필드 필수 → 옵션으로 변경됨 (breaking 아님, 기존 요청 그대로 동작)

  🔗 관련 이슈
