### PR TITLE
chore(deps): CVE 패치 — Spring Boot 3.5.12 및 보안 취약점 라이브러리 버전 업그레이드

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,7 +29,6 @@ subprojects {
     // CVE 패치: Spring Boot BOM 미관리 라이브러리 버전 강제 지정
     dependencyManagement {
         dependencies {
-            dependency 'commons-fileupload:commons-fileupload:1.5'
             dependency 'commons-beanutils:commons-beanutils:1.9.4'
             dependency 'org.bitbucket.b_c:jose4j:0.9.6'
         }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.owasp.dependencycheck' version '9.0.9'
-    id 'org.springframework.boot' version '3.5.7' apply(false)
+    id 'org.springframework.boot' version '3.5.12' apply(false)
     id 'io.spring.dependency-management' version '1.1.7' apply(false)
 }
 
@@ -19,6 +19,20 @@ subprojects {
         plugin 'java'
         plugin 'io.spring.dependency-management'
         plugin 'org.owasp.dependencycheck'  // ← 이거 추가!
+    }
+
+    // CVE 패치: Spring Boot BOM 관리 라이브러리 버전 강제 오버라이드
+    ext['netty.version'] = '4.1.132.Final'
+    ext['h2.version'] = '2.2.220'
+    ext['commons-io.version'] = '2.17.0'
+
+    // CVE 패치: Spring Boot BOM 미관리 라이브러리 버전 강제 지정
+    dependencyManagement {
+        dependencies {
+            dependency 'commons-fileupload:commons-fileupload:1.5'
+            dependency 'commons-beanutils:commons-beanutils:1.9.4'
+            dependency 'org.bitbucket.b_c:jose4j:0.9.6'
+        }
     }
 
     java {


### PR DESCRIPTION
🎯 작업 타겟 (Monorepo)

  - [x] Backend

  🔍 작업 내용 (What)

  - Spring Boot 3.5.7 → 3.5.12 업그레이드
  - Netty 4.1.128.Final → 4.1.132.Final 업그레이드
  - Commons IO → 2.17.0 업그레이드
  - Commons FileUpload → 1.5 업그레이드
  - Commons BeanUtils → 1.9.4 업그레이드
  - jose4j 0.9.5 → 0.9.6 업그레이드
  - H2 2.1.214 → 2.2.220 업그레이드 (테스트 전용)

  📸 스크린샷 / 아키텍처 / 로그 (필수)

  BUILD SUCCESSFUL in 24s
  23 actionable tasks: 23 executed

  Netty 버전 반영 확인:
  io.netty:netty-common:4.1.109.Final -> 4.1.132.Final
  io.netty:netty-codec:4.1.109.Final  -> 4.1.132.Final

  H2 버전 반영 확인:
  com.h2database:h2 -> 2.2.220

  ❓ 변경 이유 (Why)

  보안팀 CVE 취약점 점검 결과, 현재 사용 중인 라이브러리 일부에서 보안 취약점이 발견됨. 루트 build.gradle 한 곳에서 전체
   모듈에 버전을 일괄 적용하여 관리 포인트를 최소화함.

  📋 체크리스트

  - [x] 로컬 환경에서 빌드 및 테스트 성공 확인
  - [x] 민감 정보 하드코딩 없음
  - [x] 불필요한 로그 없음
  - [x] 프론트 영향 없음 — 라이브러리 버전 변경만이며 API 스펙 변경 없음

  🔗 관련 이슈

  Resolves: 보안팀 CVE 취약점 대응 요청