### PR TITLE
[feat(backend)] 대기열 배치 pace별 독립 락 및 재시도 큐 구현

### DIFF
--- a/backend/common/src/main/java/com/kt/onrace/common/util/RedisKeyGenerator.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/util/RedisKeyGenerator.java
@@ -97,8 +97,12 @@ public class RedisKeyGenerator {
 		return String.format("queue:pass:%d:%d", paceId, userId);
 	}
 
-	public static String queueBatchLock() {
-		return "queue:batch:lock";
+	public static String queueRetry(Long paceId) {
+		return String.format("queue:retry:%d", paceId);
+	}
+
+	public static String queueBatchLock(Long paceId) {
+		return String.format("queue:batch:lock:%d", paceId);
 	}
 
 	public static String queueActivePaces() {

--- a/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
@@ -1,12 +1,15 @@
 package com.kt.onrace.queue.processor;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.redisson.api.RBucket;
+import org.redisson.api.RDeque;
 import org.redisson.api.RLock;
 import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RScript;
 import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
@@ -30,11 +33,35 @@ public class QueueBatchScheduler {
 	private final QueueTokenGenerator queueTokenGenerator;
 
 	private static final long LOCK_LEASE_SECONDS = 30;
+	private static final int MAX_RETRY_COUNT = 3;
+	private static final String RETRY_SEPARATOR = ":";
+
+	// 대기열(waiting)과 재시도 큐(retry)가 모두 비어있을 때만 activePaces에서 제거
+	private static final String REMOVE_IF_EMPTY_SCRIPT =
+		"if redis.call('ZCARD', KEYS[1]) == 0 and redis.call('LLEN', KEYS[2]) == 0 then " +
+			"redis.call('SREM', KEYS[3], ARGV[1]) " +
+			"return 1 " +
+		"end " +
+		"return 0";
 
 	@Scheduled(fixedDelayString = "${queue.interval-ms}")
 	public void processBatch() {
-		// Redisson RLock을 사용한 분산 락
-		RLock lock = redissonClient.getLock(RedisKeyGenerator.queueBatchLock());
+		RSet<String> activePaces = redissonClient.getSet(RedisKeyGenerator.queueActivePaces(), StringCodec.INSTANCE);
+		Set<String> paceIds = activePaces.readAll();
+
+		for (String paceIdStr : paceIds) {
+			try {
+				Long paceId = Long.parseLong(paceIdStr);
+				processPaceQueue(paceId);
+			} catch (Exception e) {
+				log.error("배치 처리 오류 - paceId={}, error={}", paceIdStr, e.getMessage());
+			}
+		}
+	}
+
+	private void processPaceQueue(Long paceId) {
+		// pace별 분산 락 획득
+		RLock lock = redissonClient.getLock(RedisKeyGenerator.queueBatchLock(paceId));
 
 		boolean acquired;
 		try {
@@ -43,23 +70,42 @@ public class QueueBatchScheduler {
 			Thread.currentThread().interrupt();
 			return;
 		}
-
 		if (!acquired) {
 			return;
 		}
 
 		try {
-			RSet<String> activePaces = redissonClient.getSet(RedisKeyGenerator.queueActivePaces(), StringCodec.INSTANCE);
-			Set<String> paceIds = activePaces.readAll();
+			RDeque<String> retryQueue = redissonClient.getDeque(
+				RedisKeyGenerator.queueRetry(paceId), StringCodec.INSTANCE);
+			RScoredSortedSet<String> waitingSet = redissonClient.getScoredSortedSet(
+				RedisKeyGenerator.queueWaiting(paceId), StringCodec.INSTANCE);
+			int batchSize = queueProperties.getBatchSize();
+			long passTtl = queueProperties.getPassTtlSeconds();
 
-			for (String paceIdStr : paceIds) {
-				try {
-					Long paceId = Long.parseLong(paceIdStr);
-					processPaceQueue(paceId, activePaces);
-				} catch (Exception e) {
-					log.error("배치 처리 오류 - paceId={}, error={}", paceIdStr, e.getMessage());
+			// 1단계: 재시도 큐 우선 처리
+			int issued = processRetryQueue(retryQueue, paceId, passTtl);
+
+			// 2단계: 남은 배치 여유분만큼 대기열에서 처리
+			int remaining = batchSize - issued;
+			if (remaining > 0) {
+				Collection<String> popped = waitingSet.pollFirst(remaining);
+
+				if ((popped == null || popped.isEmpty()) && issued == 0) {
+					removeActivePaceIfEmpty(paceId);
+					return;
+				}
+
+				if (popped != null) {
+					for (String userIdStr : popped) {
+						if (userIdStr == null) {
+							continue;
+						}
+						issuePassToken(userIdStr, paceId, passTtl, retryQueue, 0);
+					}
 				}
 			}
+
+			removeActivePaceIfEmpty(paceId);
 		} finally {
 			if (lock.isHeldByCurrentThread()) {
 				lock.unlock();
@@ -67,37 +113,68 @@ public class QueueBatchScheduler {
 		}
 	}
 
-	private void processPaceQueue(Long paceId, RSet<String> activePaces) {
-		RScoredSortedSet<String> waitingSet = redissonClient.getScoredSortedSet(
-			RedisKeyGenerator.queueWaiting(paceId), StringCodec.INSTANCE);
-		int batchSize = queueProperties.getBatchSize();
-		long passTtl = queueProperties.getPassTtlSeconds();
+	private int processRetryQueue(RDeque<String> retryQueue, Long paceId, long passTtl) {
+		int issued = 0;
 
-		Collection<String> popped = waitingSet.pollFirst(batchSize);
+		String entry;
 
-		if (popped == null || popped.isEmpty()) {
-			// 대기열이 비었으면 활성 SET에서 제거
-			if (waitingSet.isEmpty()) {
-				activePaces.remove(String.valueOf(paceId));
-			}
-			return;
-		}
+		while ((entry = retryQueue.pollFirst()) != null) {
+			String userId = parseUserId(entry);
+			int retryCount = parseRetryCount(entry);
 
-		for (String userIdStr : popped) {
-			if (userIdStr == null) {
+			if (retryCount >= MAX_RETRY_COUNT) {
+				log.warn("최대 재시도 횟수 초과, 사용자 제거 - paceId={}, userId={}, retryCount={}", paceId, userId, retryCount);
 				continue;
 			}
 
+			if (issuePassToken(userId, paceId, passTtl, retryQueue, retryCount)) {
+				issued++;
+			}
+		}
+		return issued;
+	}
+
+	private boolean issuePassToken(String userIdStr, Long paceId, long passTtl, RDeque<String> retryQueue, int retryCount) {
+		try {
 			Long userId = Long.parseLong(userIdStr);
 			String passKey = RedisKeyGenerator.queuePass(paceId, userId);
 			String passToken = queueTokenGenerator.generatePassToken(userId, paceId);
 			RBucket<String> passBucket = redissonClient.getBucket(passKey, StringCodec.INSTANCE);
 			passBucket.set(passToken, passTtl, TimeUnit.SECONDS);
+			return true;
+		} catch (Exception e) {
+			int nextRetry = retryCount + 1;
+			log.error("통과 토큰 발급 실패, 재시도 큐 등록 ({}/{}) - paceId={}, userId={}",
+				nextRetry, MAX_RETRY_COUNT, paceId, userIdStr, e);
+			retryQueue.addLast(userIdStr + RETRY_SEPARATOR + nextRetry);
+			return false;
 		}
+	}
 
-		// 모든 사용자를 통과시킨 뒤 대기열이 비었으면 활성 SET에서 제거
-		if (waitingSet.isEmpty()) {
-			activePaces.remove(String.valueOf(paceId));
+	private String parseUserId(String entry) {
+		int idx = entry.indexOf(RETRY_SEPARATOR);
+		return (idx == -1) ? entry : entry.substring(0, idx);
+	}
+
+	private int parseRetryCount(String entry) {
+		int idx = entry.indexOf(RETRY_SEPARATOR);
+		if (idx == -1) {
+			return 0;
 		}
+		try {
+			return Integer.parseInt(entry.substring(idx + 1));
+		} catch (NumberFormatException e) {
+			return 0;
+		}
+	}
+
+	private void removeActivePaceIfEmpty(Long paceId) {
+		RScript script = redissonClient.getScript(StringCodec.INSTANCE);
+		script.eval(RScript.Mode.READ_WRITE, REMOVE_IF_EMPTY_SCRIPT, RScript.ReturnType.INTEGER,
+			List.of(
+				RedisKeyGenerator.queueWaiting(paceId),
+				RedisKeyGenerator.queueRetry(paceId),
+				RedisKeyGenerator.queueActivePaces()),
+			String.valueOf(paceId));
 	}
 }

--- a/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
@@ -83,7 +83,7 @@ public class QueueBatchScheduler {
 			long passTtl = queueProperties.getPassTtlSeconds();
 
 			// 1단계: 재시도 큐 우선 처리
-			int issued = processRetryQueue(retryQueue, paceId, passTtl);
+			int issued = processRetryQueue(retryQueue, paceId, passTtl, batchSize);
 
 			// 2단계: 남은 배치 여유분만큼 대기열에서 처리
 			int remaining = batchSize - issued;
@@ -113,12 +113,12 @@ public class QueueBatchScheduler {
 		}
 	}
 
-	private int processRetryQueue(RDeque<String> retryQueue, Long paceId, long passTtl) {
+	private int processRetryQueue(RDeque<String> retryQueue, Long paceId, long passTtl, int batchSize) {
 		int issued = 0;
 
 		String entry;
 
-		while ((entry = retryQueue.pollFirst()) != null) {
+		while (issued < batchSize && (entry = retryQueue.pollFirst()) != null) {
 			String userId = parseUserId(entry);
 			int retryCount = parseRetryCount(entry);
 

--- a/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
@@ -86,24 +86,7 @@ public class QueueBatchScheduler {
 			int issued = processRetryQueue(retryQueue, paceId, passTtl, batchSize);
 
 			// 2단계: 남은 배치 여유분만큼 대기열에서 처리
-			int remaining = batchSize - issued;
-			if (remaining > 0) {
-				Collection<String> popped = waitingSet.pollFirst(remaining);
-
-				if ((popped == null || popped.isEmpty()) && issued == 0) {
-					removeActivePaceIfEmpty(paceId);
-					return;
-				}
-
-				if (popped != null) {
-					for (String userIdStr : popped) {
-						if (userIdStr == null) {
-							continue;
-						}
-						issuePassToken(userIdStr, paceId, passTtl, retryQueue, 0);
-					}
-				}
-			}
+			issued += processWaitingQueue(waitingSet, paceId, passTtl, retryQueue, batchSize - issued);
 
 			removeActivePaceIfEmpty(paceId);
 		} finally {
@@ -111,6 +94,27 @@ public class QueueBatchScheduler {
 				lock.unlock();
 			}
 		}
+	}
+
+	private int processWaitingQueue(RScoredSortedSet<String> waitingSet, Long paceId, long passTtl,
+		RDeque<String> retryQueue, int count) {
+		if (count <= 0) {
+			return 0;
+		}
+		Collection<String> popped = waitingSet.pollFirst(count);
+		if (popped == null || popped.isEmpty()) {
+			return 0;
+		}
+		int issued = 0;
+		for (String userIdStr : popped) {
+			if (userIdStr == null) {
+				continue;
+			}
+			if (issuePassToken(userIdStr, paceId, passTtl, retryQueue, 0)) {
+				issued++;
+			}
+		}
+		return issued;
 	}
 
 	private int processRetryQueue(RDeque<String> retryQueue, Long paceId, long passTtl, int batchSize) {

--- a/backend/queue/src/test/java/com/kt/onrace/queue/processor/QueueBatchSchedulerTest.java
+++ b/backend/queue/src/test/java/com/kt/onrace/queue/processor/QueueBatchSchedulerTest.java
@@ -1,0 +1,333 @@
+package com.kt.onrace.queue.processor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RBucket;
+import org.redisson.api.RDeque;
+import org.redisson.api.RLock;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RScript;
+import org.redisson.api.RSet;
+import org.redisson.api.RedissonClient;
+import org.redisson.client.codec.Codec;
+
+import com.kt.onrace.queue.config.QueueProperties;
+import com.kt.onrace.queue.security.QueueTokenGenerator;
+
+@ExtendWith(MockitoExtension.class)
+class QueueBatchSchedulerTest {
+
+	private static final Long PACE_ID = 1L;
+	private static final Long PACE_ID_2 = 2L;
+	private static final Long USER_ID = 100L;
+	private static final Long USER_ID_2 = 200L;
+	private static final int BATCH_SIZE = 100;
+	private static final long PASS_TTL = 600L;
+	private static final String PASS_TOKEN = "test-pass-token";
+
+	@Mock private RedissonClient redissonClient;
+	@Mock private QueueProperties queueProperties;
+	@Mock private QueueTokenGenerator queueTokenGenerator;
+
+	@Mock private RSet<String> activePaces;
+	@Mock private RLock lock;
+	@Mock private RDeque<String> retryQueue;
+	@Mock private RScoredSortedSet<String> waitingSet;
+	@Mock private RBucket<String> passBucket;
+	@Mock private RScript rScript;
+
+	@InjectMocks
+	private QueueBatchScheduler queueBatchScheduler;
+
+	private void givenActivePaces(String... paceIds) {
+		doReturn(activePaces).when(redissonClient).getSet(anyString(), any(Codec.class));
+		when(activePaces.readAll()).thenReturn(Set.of(paceIds));
+	}
+
+	private void givenBatchProperties() {
+		when(queueProperties.getBatchSize()).thenReturn(BATCH_SIZE);
+		when(queueProperties.getPassTtlSeconds()).thenReturn(PASS_TTL);
+	}
+
+	private void givenLockAcquired() throws InterruptedException {
+		when(redissonClient.getLock(anyString())).thenReturn(lock);
+		when(lock.tryLock(eq(0L), eq(30L), eq(TimeUnit.SECONDS))).thenReturn(true);
+		when(lock.isHeldByCurrentThread()).thenReturn(true);
+	}
+
+	private void givenLockNotAcquired() throws InterruptedException {
+		when(redissonClient.getLock(anyString())).thenReturn(lock);
+		when(lock.tryLock(eq(0L), eq(30L), eq(TimeUnit.SECONDS))).thenReturn(false);
+	}
+
+	private void givenRetryQueueEmpty() {
+		doReturn(retryQueue).when(redissonClient).getDeque(anyString(), any(Codec.class));
+		when(retryQueue.pollFirst()).thenReturn(null);
+	}
+
+	private void givenRetryQueueWith(String... entries) {
+		doReturn(retryQueue).when(redissonClient).getDeque(anyString(), any(Codec.class));
+		if (entries.length == 1) {
+			when(retryQueue.pollFirst()).thenReturn(entries[0], (String) null);
+		} else {
+			String[] rest = new String[entries.length];
+			System.arraycopy(entries, 1, rest, 0, entries.length - 1);
+			rest[entries.length - 1] = null;
+			when(retryQueue.pollFirst()).thenReturn(entries[0], rest);
+		}
+	}
+
+	private void givenWaitingSetWith(String... userIds) {
+		doReturn(waitingSet).when(redissonClient).getScoredSortedSet(anyString(), any(Codec.class));
+		when(waitingSet.pollFirst(any(int.class))).thenReturn(List.of(userIds));
+	}
+
+	private void givenWaitingSetEmpty() {
+		doReturn(waitingSet).when(redissonClient).getScoredSortedSet(anyString(), any(Codec.class));
+		when(waitingSet.pollFirst(any(int.class))).thenReturn(List.of());
+	}
+
+	private void givenTokenGeneration() {
+		when(queueTokenGenerator.generatePassToken(anyLong(), anyLong())).thenReturn(PASS_TOKEN);
+		doReturn(passBucket).when(redissonClient).getBucket(anyString(), any(Codec.class));
+	}
+
+	private void givenLuaScript() {
+		when(redissonClient.getScript(any(Codec.class))).thenReturn(rScript);
+	}
+
+	// ===== 정상 흐름 =====
+
+	@Nested
+	@DisplayName("정상 흐름")
+	class NormalFlow {
+
+		@Test
+		@DisplayName("대기열 사용자가 정상적으로 통과 토큰을 발급받는다")
+		void processBatch_issuesPassToken() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueEmpty();
+			givenWaitingSetWith(String.valueOf(USER_ID));
+			givenTokenGeneration();
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(queueTokenGenerator).generatePassToken(USER_ID, PACE_ID);
+			verify(passBucket).set(eq(PASS_TOKEN), eq(PASS_TTL), eq(TimeUnit.SECONDS));
+			verify(lock).unlock();
+		}
+
+		@Test
+		@DisplayName("여러 pace가 각각 독립적으로 처리된다")
+		void processBatch_multiPace() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID), String.valueOf(PACE_ID_2));
+			givenLockAcquired();
+			givenRetryQueueEmpty();
+			givenWaitingSetWith(String.valueOf(USER_ID));
+			givenTokenGeneration();
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(lock, times(2)).tryLock(eq(0L), eq(30L), eq(TimeUnit.SECONDS));
+			verify(queueTokenGenerator, times(2)).generatePassToken(eq(USER_ID), anyLong());
+		}
+	}
+
+	// ===== 재시도 큐 =====
+
+	@Nested
+	@DisplayName("재시도 큐")
+	class RetryQueueTest {
+
+		@Test
+		@DisplayName("토큰 발급 실패 시 재시도 큐에 등록된다")
+		void processBatch_tokenFailure_addedToRetryQueue() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueEmpty();
+			givenWaitingSetWith(String.valueOf(USER_ID));
+			when(queueTokenGenerator.generatePassToken(anyLong(), anyLong()))
+				.thenThrow(new RuntimeException("JWT 생성 실패"));
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(retryQueue).addLast(USER_ID + ":1");
+		}
+
+		@Test
+		@DisplayName("재시도 큐 사용자가 대기열보다 먼저 처리된다")
+		void processBatch_retryQueueProcessedFirst() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueWith(String.valueOf(USER_ID));
+			givenWaitingSetWith(String.valueOf(USER_ID_2));
+			givenTokenGeneration();
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(queueTokenGenerator).generatePassToken(USER_ID, PACE_ID);
+			verify(queueTokenGenerator).generatePassToken(USER_ID_2, PACE_ID);
+		}
+
+		@Test
+		@DisplayName("재시도 큐 처리 후 남은 배치 여유분만 대기열에서 처리한다")
+		void processBatch_retryReducesRemainingBatch() throws InterruptedException {
+			// given
+			when(queueProperties.getBatchSize()).thenReturn(3);
+			when(queueProperties.getPassTtlSeconds()).thenReturn(PASS_TTL);
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueWith(String.valueOf(USER_ID), String.valueOf(USER_ID_2));
+			givenTokenGeneration();
+			givenLuaScript();
+			doReturn(waitingSet).when(redissonClient).getScoredSortedSet(anyString(), any(Codec.class));
+			when(waitingSet.pollFirst(1)).thenReturn(List.of("300"));
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(waitingSet).pollFirst(1);
+		}
+	}
+
+	// ===== 최대 재시도 제한 =====
+
+	@Nested
+	@DisplayName("최대 재시도 제한")
+	class MaxRetryLimit {
+
+		@Test
+		@DisplayName("최대 재시도 횟수 초과 시 사용자가 제거된다")
+		void processBatch_maxRetryExceeded_userDropped() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueWith(USER_ID + ":3");
+			givenWaitingSetEmpty();
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(queueTokenGenerator, never()).generatePassToken(anyLong(), anyLong());
+		}
+
+		@Test
+		@DisplayName("재시도 횟수가 증가하며 기록된다")
+		void processBatch_retryCountIncremented() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueWith(USER_ID + ":1");
+			doReturn(waitingSet).when(redissonClient).getScoredSortedSet(anyString(), any(Codec.class));
+			when(waitingSet.pollFirst(any(int.class))).thenReturn(List.of());
+			when(queueTokenGenerator.generatePassToken(anyLong(), anyLong()))
+				.thenThrow(new RuntimeException("JWT 생성 실패"));
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(retryQueue).addLast(USER_ID + ":2");
+		}
+	}
+
+	// ===== 락 동작 =====
+
+	@Nested
+	@DisplayName("락 동작")
+	class LockBehavior {
+
+		@Test
+		@DisplayName("락 획득 실패 시 해당 pace를 건너뛴다")
+		void processBatch_lockNotAcquired_skipped() throws InterruptedException {
+			// given
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockNotAcquired();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(queueTokenGenerator, never()).generatePassToken(anyLong(), anyLong());
+			verify(lock, never()).unlock();
+		}
+	}
+
+	// ===== 빈 큐 정리 =====
+
+	@Nested
+	@DisplayName("빈 큐 정리")
+	class EmptyQueueCleanup {
+
+		@Test
+		@DisplayName("대기열과 재시도 큐가 모두 비었을 때 Lua 스크립트로 activePaces 정리를 시도한다")
+		void processBatch_emptyQueues_luaScriptCalled() throws InterruptedException {
+			// given
+			givenBatchProperties();
+			givenActivePaces(String.valueOf(PACE_ID));
+			givenLockAcquired();
+			givenRetryQueueEmpty();
+			givenWaitingSetEmpty();
+			givenLuaScript();
+
+			// when
+			queueBatchScheduler.processBatch();
+
+			// then
+			verify(rScript).eval(
+				eq(RScript.Mode.READ_WRITE),
+				anyString(),
+				eq(RScript.ReturnType.INTEGER),
+				any(List.class),
+				eq(String.valueOf(PACE_ID))
+			);
+		}
+	}
+}


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- pace별 독립 분산 락: 기존 글로벌 단일 락을 pace별 락으로 변경하여 한 페이스의 락이 다른 페이스 처리를 차단하지 않도록 개선
- 재시도 큐 도입: 토큰 발급 실패 시 사용자가 유실되는 문제를 해결하기 위해 별도 재시도 큐 추가
- 최대 재시도 제한: 재시도 횟수를 3회로 제한하여 브라우저 종료 등 이탈 사용자의 무한 재시도 방지
- 배치 처리 순서 변경: 재시도 큐 우선 처리 → 남은 배치 여유분만 대기열에서 처리
- activePaces 원자적 정리: waiting과 retry 큐가 모두 비었을 때만 activePaces에서 제거

## 📸 스크린샷 / 아키텍처 / 로그 (필수)
- 변경 전
processBatch()
  └─ 글로벌 락 획득 (queue:batch:lock)
      └─ 모든 pace 순회
          └─ waitingSet.pollFirst → 토큰 발급 (실패 시 사용자 유실)

- 변경 후
 processBatch()
  └─ activePaces 조회
      └─ pace별 독립 처리 (processPaceQueue)
          ├─ pace별 락 획득 (queue:batch:lock:{paceId})
          ├─ 1단계: 재시도 큐 우선 처리 (retry:{paceId})
          ├─ 2단계: 남은 배치 여유분만 대기열에서 처리 (waiting:{paceId})
          ├─ 토큰 발급 실패 시 → 재시도 큐 등록 (userId:retryCount)
          ├─ 최대 재시도(3회) 초과 시 → 사용자 제거
          └─ Lua 스크립트로 빈 큐 정리 (ZCARD+LLEN+SREM 원자적)

## ❓ 변경 이유 (Why)
구조적 이슈 해결
1. 글로벌 락 병목: 페이스 A의 처리가 느릴 때 페이스 B도 대기해야 하는 구조 → pace별 독립 락으로 격리
2. 사용자 유실 버그: 토큰 발급(JWT 생성) 실패 시 사용자가 대기열에서 이미 제거된 상태로 복구 불가 → 재시도 큐로 안전하게 재처리
3. 레이스 컨디션: activePaces.remove()와 enter()의 activePaces.add()가 동시 실행 시 데이터 불일치 → Lua 스크립트로 원자적 처리

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
