### PR TITLE
feat(backend): 커스텀 Prometheus 메트릭 및 Loki 비즈니스 로그 추가

### DIFF
--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -217,9 +217,9 @@ public class EntryService {
 		long result = eventStockService.tryReserveStock(pace.getId(), userId);
 
 		if (result == -2) {
-			log.warn("[ENTRY] 중복 선점 시도 userId={}, paceId={}", userId, pace.getId());
+			log.info("[ENTRY] 중복 선점 시도 userId={}, paceId={}", userId, pace.getId());
 		} else if (result == -1) {
-			log.warn("[ENTRY] 선착순 매진 userId={}, paceId={}", userId, pace.getId());
+			log.info("[ENTRY] 선착순 매진 userId={}, paceId={}", userId, pace.getId());
 		}
 
 		Preconditions.validate(result != -2, BusinessErrorCode.ENTRY_ALREADY_RESERVED);
@@ -253,7 +253,7 @@ public class EntryService {
 
 		if(available > 0) {
 			EntryStockCheckResponse result = EntryStockCheckResponse.available(available);
-			log.info("[STOCK] 재고 조회 paceId={}, status={}, available={}", paceId, result.stockStatus(), result.remainingStock());
+			log.debug("[STOCK] 재고 조회 paceId={}, status={}, available={}", paceId, result.stockStatus(), result.remainingStock());
 			return result;
 		}
 
@@ -261,11 +261,11 @@ public class EntryService {
 		long confirmed = eventStockService.getConfirmStock(paceId);
 
 		if(confirmed >= total) {
-			log.info("[STOCK] 재고 조회 paceId={}, status=SOLD_OUT, available=0", paceId);
+			log.debug("[STOCK] 재고 조회 paceId={}, status=SOLD_OUT, available=0", paceId);
 			return EntryStockCheckResponse.soldOut();
 		}
 
-		log.info("[STOCK] 재고 조회 paceId={}, status=TEMP_SOLD_OUT, available=0", paceId);
+		log.debug("[STOCK] 재고 조회 paceId={}, status=TEMP_SOLD_OUT, available=0", paceId);
 		return EntryStockCheckResponse.tempSoldOut();
 	}
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -85,6 +85,8 @@ public class EntryService {
 
 		entryRepository.save(entry);
 
+		log.info("[ENTRY] 사전정보 저장 userId={}, eventId={}, courseId={}, paceId={}", userId, eventId, request.courseId(), request.paceId());
+
 		return EntryPreSaveResponse.from(entry);
 	}
 
@@ -152,6 +154,8 @@ public class EntryService {
 
 		entryRepository.deleteByUserIdAndEventId(userId, eventId);
 
+		log.info("[ENTRY] 사전정보 삭제 userId={}, eventId={}, entryId={}", userId, eventId, entry.getId());
+
 		return entry.getId();
 	}
 
@@ -181,6 +185,9 @@ public class EntryService {
 		EventPace pace = eventPaceRepository.findByIdAndEventCourseIdOrThrow(request.paceId(), request.courseId(),
 				BusinessErrorCode.ENTRY_PACE_NOT_FOUND);
 
+		log.info("[ENTRY] 신청 시작 userId={}, eventId={}, appType={}, courseId={}, paceId={}",
+			userId, eventId, expectedAppType, request.courseId(), request.paceId());
+
 		return switch (event.getAppType()) {
 			case LOTTERY -> applyLottery(userId, event, course, pace);
 			case FIRST_COME -> applyFirstCome(userId, event, course, pace);
@@ -191,6 +198,8 @@ public class EntryService {
 		Entry entry = getCreateEntry(userId, event);
 		entry.apply(course, pace);
 		entryRepository.save(entry);
+
+		log.info("[ENTRY] 추첨 신청 완료 userId={}, eventId={}, entryId={}", userId, event.getId(), entry.getId());
 
 		return EntryApplyResponse.from(entry);
 	}
@@ -206,8 +215,17 @@ public class EntryService {
 		}
 
 		long result = eventStockService.tryReserveStock(pace.getId(), userId);
+
+		if (result == -2) {
+			log.warn("[ENTRY] 중복 선점 시도 userId={}, paceId={}", userId, pace.getId());
+		} else if (result == -1) {
+			log.warn("[ENTRY] 선착순 매진 userId={}, paceId={}", userId, pace.getId());
+		}
+
 		Preconditions.validate(result != -2, BusinessErrorCode.ENTRY_ALREADY_RESERVED);
 		Preconditions.validate(result != -1, BusinessErrorCode.ENTRY_SOLD_OUT);
+
+		log.info("[ENTRY] 선착순 선점 성공 userId={}, paceId={}, remaining={}", userId, pace.getId(), result);
 
 		entry.reserve(course, pace);
 		entryRepository.save(entry);
@@ -234,16 +252,20 @@ public class EntryService {
 		long available = eventStockService.getTempStock(paceId);
 
 		if(available > 0) {
-			return EntryStockCheckResponse.available(available);
+			EntryStockCheckResponse result = EntryStockCheckResponse.available(available);
+			log.info("[STOCK] 재고 조회 paceId={}, status={}, available={}", paceId, result.stockStatus(), result.remainingStock());
+			return result;
 		}
 
 		long total = eventStockService.getTotalStock(paceId);
 		long confirmed = eventStockService.getConfirmStock(paceId);
 
 		if(confirmed >= total) {
+			log.info("[STOCK] 재고 조회 paceId={}, status=SOLD_OUT, available=0", paceId);
 			return EntryStockCheckResponse.soldOut();
 		}
 
+		log.info("[STOCK] 재고 조회 paceId={}, status=TEMP_SOLD_OUT, available=0", paceId);
 		return EntryStockCheckResponse.tempSoldOut();
 	}
 
@@ -263,6 +285,8 @@ public class EntryService {
 		}
 
 		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
+
+		log.info("[ENTRY] 결제 확정 userId={}, paceId={}, appType={}", userId, paceId, type);
 
 		// 왜? 위의 if로 넣지 않느냐 -> 트랜잭션 커밋이 안된 상태에서 redis는 즉시 실행되고 DB 업데이트는 트랜잭션 커밋 시점에 반영되기
 		// 때문에 DB가 실패할 시 redis는 롤백이 안되므로, DB가 성공적으로 끝난 후 redis를 실행하는 것이 맞음

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -63,7 +63,14 @@ public class EventStockService {
 
 		stockMetrics.recordReserveResult(paceId, result);
 
-		String resultDesc = result >= 0 ? "성공(남은:" + result + ")" : result == -1 ? "매진" : "중복";
+		String resultDesc;
+		if (result >= 0) {
+			resultDesc = "성공(남은:" + result + ")";
+		} else if (result == -1) {
+			resultDesc = "매진";
+		} else {
+			resultDesc = "중복";
+		}
 		log.info("[STOCK] 재고 선점 paceId={}, userId={}, result={}", paceId, userId, resultDesc);
 
 		return result;

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -63,8 +63,8 @@ public class EventStockService {
 
 		stockMetrics.recordReserveResult(paceId, result);
 
-		log.info("[STOCK] 재고 선점 paceId={}, userId={}, result={}", paceId, userId,
-			result >= 0 ? "성공(남은:" + result + ")" : result == -1 ? "매진" : "중복");
+		String resultDesc = result >= 0 ? "성공(남은:" + result + ")" : result == -1 ? "매진" : "중복";
+		log.info("[STOCK] 재고 선점 paceId={}, userId={}, result={}", paceId, userId, resultDesc);
 
 		return result;
 	}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -13,12 +13,16 @@ import com.kt.onrace.common.util.RedisKeyGenerator;
 import com.kt.onrace.domain.entry.config.EntryProperties;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EventStockService {
 	private final RedissonClient redissonClient;
 	private final EntryProperties entryProperties;
+	private final StockMetrics stockMetrics;
+
 	private static final String RESERVE_SCRIPT =
 		"if redis.call('EXISTS', KEYS[1]) == 1 then return -2 end " +
 			"local stock = redis.call('DECR', KEYS[2]) " +
@@ -36,6 +40,12 @@ public class EventStockService {
 
 		RAtomicLong confirm = redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId));
 		confirm.set(confirmedStock);
+
+		stockMetrics.registerStockGauges(paceId,
+			() -> redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId)).get(),
+			() -> redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId)).get());
+
+		log.info("[STOCK] 재고 초기화 paceId={}, total={}, confirmed={}", paceId, totalStock, confirmedStock);
 	}
 
 	public long tryReserveStock(Long paceId, Long userId) {
@@ -43,13 +53,20 @@ public class EventStockService {
 
 		// -2: 이미 선점된 경우, -1: 재고 부족, 0 이상: 선점 성공 (남은 재고 수)
 		// eval 자체가 내부적으로 EVALSHA → NOSCRIPT fallback을 자동으로 진행해줘서 인프라 요구사항에 충족할 수 잇음!
-		return script.eval(
+		long result = script.eval(
 			RScript.Mode.READ_WRITE,
 			RESERVE_SCRIPT,
 			RScript.ReturnType.INTEGER,
 			List.of(RedisKeyGenerator.reservationKey(paceId, userId), RedisKeyGenerator.tempStockKey(paceId)),
 			String.valueOf(entryProperties.getTtlSeconds())
 		);
+
+		stockMetrics.recordReserveResult(paceId, result);
+
+		log.info("[STOCK] 재고 선점 paceId={}, userId={}, result={}", paceId, userId,
+			result >= 0 ? "성공(남은:" + result + ")" : result == -1 ? "매진" : "중복");
+
+		return result;
 	}
 
 	public long getTotalStock(Long paceId) {
@@ -75,6 +92,7 @@ public class EventStockService {
 
 	public void restoreStock(Long paceId) {
 		redissonClient.getAtomicLong(RedisKeyGenerator.tempStockKey(paceId)).incrementAndGet();
+		log.info("[STOCK] 재고 복원 paceId={}", paceId);
 	}
 
 	public boolean hasReservation(Long paceId, Long userId) {
@@ -92,6 +110,7 @@ public class EventStockService {
 	public void confirmStock(Long paceId) {
 		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId));
 		stock.incrementAndGet();
+		log.info("[STOCK] 재고 확정 paceId={}", paceId);
 	}
 
 	public void cancelConfirmedStock(Long paceId) {

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/StockMetrics.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/StockMetrics.java
@@ -1,5 +1,7 @@
 package com.kt.onrace.domain.event.service;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -12,7 +14,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 @Component
 public class StockMetrics {
 
+	private static final String TAG_PACE_ID = "paceId";
+
 	private final MeterRegistry registry;
+	private final Set<Long> registeredPaceIds = ConcurrentHashMap.newKeySet();
 
 	public StockMetrics(ObjectProvider<MeterRegistry> registryProvider) {
 		this.registry = registryProvider.getIfAvailable();
@@ -27,7 +32,7 @@ public class StockMetrics {
 			default -> "success";
 		};
 		Counter.builder("stock.reserve.total")
-			.tag("paceId", String.valueOf(paceId))
+			.tag(TAG_PACE_ID, String.valueOf(paceId))
 			.tag("result", resultTag)
 			.register(registry)
 			.increment();
@@ -38,12 +43,13 @@ public class StockMetrics {
 		Supplier<Number> tempStockSupplier,
 		Supplier<Number> confirmStockSupplier) {
 		if (registry == null) return;
+		if (!registeredPaceIds.add(paceId)) return;
 		String paceIdStr = String.valueOf(paceId);
 		Gauge.builder("stock.remaining", tempStockSupplier)
-			.tag("paceId", paceIdStr).tag("type", "temp")
+			.tag(TAG_PACE_ID, paceIdStr).tag("type", "temp")
 			.register(registry);
 		Gauge.builder("stock.remaining", confirmStockSupplier)
-			.tag("paceId", paceIdStr).tag("type", "confirm")
+			.tag(TAG_PACE_ID, paceIdStr).tag("type", "confirm")
 			.register(registry);
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/StockMetrics.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/StockMetrics.java
@@ -1,0 +1,49 @@
+package com.kt.onrace.domain.event.service;
+
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Component
+public class StockMetrics {
+
+	private final MeterRegistry registry;
+
+	public StockMetrics(ObjectProvider<MeterRegistry> registryProvider) {
+		this.registry = registryProvider.getIfAvailable();
+	}
+
+	// 재고 예약 결과 기록
+	public void recordReserveResult(Long paceId, long result) {
+		if (registry == null) return;
+		String resultTag = switch ((int)Math.min(result, 0)) {
+			case -2 -> "fail";
+			case -1 -> "sold_out";
+			default -> "success";
+		};
+		Counter.builder("stock.reserve.total")
+			.tag("paceId", String.valueOf(paceId))
+			.tag("result", resultTag)
+			.register(registry)
+			.increment();
+	}
+
+	// 잔여 재고 Gauge 등록 — Prometheus scrape 시점에 supplier를 통해 Redis 조회
+	public void registerStockGauges(Long paceId,
+		Supplier<Number> tempStockSupplier,
+		Supplier<Number> confirmStockSupplier) {
+		if (registry == null) return;
+		String paceIdStr = String.valueOf(paceId);
+		Gauge.builder("stock.remaining", tempStockSupplier)
+			.tag("paceId", paceIdStr).tag("type", "temp")
+			.register(registry);
+		Gauge.builder("stock.remaining", confirmStockSupplier)
+			.tag("paceId", paceIdStr).tag("type", "confirm")
+			.register(registry);
+	}
+}

--- a/backend/queue/src/main/java/com/kt/onrace/queue/config/QueueMetrics.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/config/QueueMetrics.java
@@ -16,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class QueueMetrics {
 
+	private static final String TAG_PACE_ID = "paceId";
+
 	private final MeterRegistry registry;
 	private final ConcurrentHashMap<Long, AtomicLong> waitingSizeMap = new ConcurrentHashMap<>();
 
@@ -28,7 +30,7 @@ public class QueueMetrics {
 	public void recordEnter(Long paceId) {
 		if (registry == null) return;
 		Counter.builder("queue.enter.total")
-			.tag("paceId", String.valueOf(paceId))
+			.tag(TAG_PACE_ID, String.valueOf(paceId))
 			.register(registry)
 			.increment();
 	}
@@ -37,7 +39,7 @@ public class QueueMetrics {
 	public void recordPass(Long paceId, int count) {
 		if (registry == null || count <= 0) return;
 		Counter.builder("queue.pass.total")
-			.tag("paceId", String.valueOf(paceId))
+			.tag(TAG_PACE_ID, String.valueOf(paceId))
 			.register(registry)
 			.increment(count);
 	}
@@ -60,7 +62,7 @@ public class QueueMetrics {
 		AtomicLong gauge = waitingSizeMap.computeIfAbsent(paceId, id -> {
 			AtomicLong value = new AtomicLong(0);
 			Gauge.builder("queue.waiting.size", value, AtomicLong::doubleValue)
-				.tag("paceId", String.valueOf(id))
+				.tag(TAG_PACE_ID, String.valueOf(id))
 				.register(registry);
 			return value;
 		});

--- a/backend/queue/src/main/java/com/kt/onrace/queue/config/QueueMetrics.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/config/QueueMetrics.java
@@ -1,0 +1,69 @@
+package com.kt.onrace.queue.config;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class QueueMetrics {
+
+	private final MeterRegistry registry;
+	private final ConcurrentHashMap<Long, AtomicLong> waitingSizeMap = new ConcurrentHashMap<>();
+
+	public QueueMetrics(ObjectProvider<MeterRegistry> registryProvider) {
+		this.registry = registryProvider.getIfAvailable();
+	}
+
+
+	// 대기열 진입 성공 시 호출
+	public void recordEnter(Long paceId) {
+		if (registry == null) return;
+		Counter.builder("queue.enter.total")
+			.tag("paceId", String.valueOf(paceId))
+			.register(registry)
+			.increment();
+	}
+
+	// 배치 통과 인원 기록
+	public void recordPass(Long paceId, int count) {
+		if (registry == null || count <= 0) return;
+		Counter.builder("queue.pass.total")
+			.tag("paceId", String.valueOf(paceId))
+			.register(registry)
+			.increment(count);
+	}
+
+	// 배치 처리 시간 측정 시작
+	public Timer.Sample startBatchTimer() {
+		if (registry == null) return null;
+		return Timer.start(registry);
+	}
+
+	// 배치 처리 시간 측정 종료
+	public void stopBatchTimer(Timer.Sample sample) {
+		if (sample == null || registry == null) return;
+		sample.stop(Timer.builder("queue.batch.duration").register(registry));
+	}
+
+	// 대기열 크기 Gauge 갱신 — paceId별 최초 호출 시 자동 등록
+	public void updateWaitingSize(Long paceId, long size) {
+		if (registry == null) return;
+		AtomicLong gauge = waitingSizeMap.computeIfAbsent(paceId, id -> {
+			AtomicLong value = new AtomicLong(0);
+			Gauge.builder("queue.waiting.size", value, AtomicLong::doubleValue)
+				.tag("paceId", String.valueOf(id))
+				.register(registry);
+			return value;
+		});
+		gauge.set(size);
+	}
+}

--- a/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
@@ -17,9 +17,11 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.kt.onrace.common.util.RedisKeyGenerator;
+import com.kt.onrace.queue.config.QueueMetrics;
 import com.kt.onrace.queue.config.QueueProperties;
 import com.kt.onrace.queue.security.QueueTokenGenerator;
 
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +33,7 @@ public class QueueBatchScheduler {
 	private final RedissonClient redissonClient;
 	private final QueueProperties queueProperties;
 	private final QueueTokenGenerator queueTokenGenerator;
+	private final QueueMetrics queueMetrics;
 
 	private static final long LOCK_LEASE_SECONDS = 30;
 	private static final int MAX_RETRY_COUNT = 3;
@@ -46,16 +49,22 @@ public class QueueBatchScheduler {
 
 	@Scheduled(fixedDelayString = "${queue.interval-ms}")
 	public void processBatch() {
-		RSet<String> activePaces = redissonClient.getSet(RedisKeyGenerator.queueActivePaces(), StringCodec.INSTANCE);
-		Set<String> paceIds = activePaces.readAll();
+		Timer.Sample sample = queueMetrics.startBatchTimer();
 
-		for (String paceIdStr : paceIds) {
-			try {
-				Long paceId = Long.parseLong(paceIdStr);
-				processPaceQueue(paceId);
-			} catch (Exception e) {
-				log.error("배치 처리 오류 - paceId={}, error={}", paceIdStr, e.getMessage());
+		try {
+			RSet<String> activePaces = redissonClient.getSet(RedisKeyGenerator.queueActivePaces(), StringCodec.INSTANCE);
+			Set<String> paceIds = activePaces.readAll();
+
+			for (String paceIdStr : paceIds) {
+				try {
+					Long paceId = Long.parseLong(paceIdStr);
+					processPaceQueue(paceId);
+				} catch (Exception e) {
+					log.error("배치 처리 오류 - paceId={}, error={}", paceIdStr, e.getMessage());
+				}
 			}
+		} finally {
+			queueMetrics.stopBatchTimer(sample);
 		}
 	}
 
@@ -87,6 +96,14 @@ public class QueueBatchScheduler {
 
 			// 2단계: 남은 배치 여유분만큼 대기열에서 처리
 			issued += processWaitingQueue(waitingSet, paceId, passTtl, retryQueue, batchSize - issued);
+
+			// 메트릭 기록
+			queueMetrics.recordPass(paceId, issued);
+			queueMetrics.updateWaitingSize(paceId, waitingSet.size());
+
+			if (issued > 0) {
+				log.info("[QUEUE] 배치 처리 완료 paceId={}, issued={}, waiting={}", paceId, issued, waitingSet.size());
+			}
 
 			removeActivePaceIfEmpty(paceId);
 		} finally {
@@ -145,6 +162,7 @@ public class QueueBatchScheduler {
 			String passToken = queueTokenGenerator.generatePassToken(userId, paceId);
 			RBucket<String> passBucket = redissonClient.getBucket(passKey, StringCodec.INSTANCE);
 			passBucket.set(passToken, passTtl, TimeUnit.SECONDS);
+			log.info("[QUEUE] 통과 토큰 발급 userId={}, paceId={}", userId, paceId);
 			return true;
 		} catch (Exception e) {
 			int nextRetry = retryCount + 1;

--- a/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
@@ -12,6 +12,7 @@ import com.kt.onrace.common.exception.BusinessException;
 import com.kt.onrace.common.logging.annotation.ServiceLog;
 import com.kt.onrace.common.util.Preconditions;
 import com.kt.onrace.common.util.RedisKeyGenerator;
+import com.kt.onrace.queue.config.QueueMetrics;
 import com.kt.onrace.queue.dto.QueueEnterResponse;
 import com.kt.onrace.queue.dto.QueueStatusResponse;
 
@@ -23,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class QueueService {
 	private final RedissonClient redissonClient;
+	private final QueueMetrics queueMetrics;
 
 	@ServiceLog
 	public QueueEnterResponse enter(Long userId, Long paceId) {
@@ -41,8 +43,12 @@ public class QueueService {
 		RSet<String> activePaces = redissonClient.getSet(RedisKeyGenerator.queueActivePaces(), StringCodec.INSTANCE);
 		activePaces.add(String.valueOf(paceId));
 
+		queueMetrics.recordEnter(paceId);
+
 		Integer rank = waitingSet.rank(String.valueOf(userId));
 		long position = (rank != null) ? rank + 1 : 1;
+
+		log.info("[QUEUE] 대기열 진입 userId={}, paceId={}, position={}", userId, paceId, position);
 
 		return QueueEnterResponse.of(paceId, position);
 	}
@@ -54,6 +60,7 @@ public class QueueService {
 		String passToken = passBucket.get();
 
 		if (passToken != null) {
+			log.info("[QUEUE] 통과 확인 userId={}, paceId={}", userId, paceId);
 			return QueueStatusResponse.pass(paceId, passToken);
 		}
 
@@ -62,6 +69,7 @@ public class QueueService {
 		Integer rank = waitingSet.rank(String.valueOf(userId));
 
 		if (rank != null) {
+			log.debug("[QUEUE] 대기 중 userId={}, paceId={}, position={}", userId, paceId, rank + 1);
 			return QueueStatusResponse.waiting(paceId, (long) rank + 1);
 		}
 
@@ -79,5 +87,7 @@ public class QueueService {
 		boolean deletedPass = passBucket.delete();
 
 		Preconditions.validate(removedFromWaiting || deletedPass, BusinessErrorCode.QUEUE_NOT_FOUND);
+
+		log.info("[QUEUE] 대기열 이탈 userId={}, paceId={}", userId, paceId);
 	}
 }


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
1. 커스텀 Prometheus 메트릭 전담 클래스 생성 및 6종 메트릭 등록
- QueueMetrics (queue 모듈): queue_enter_total, queue_pass_total, queue_batch_duration_seconds, queue_waiting_size
- StockMetrics (main 모듈): stock_reserve_total, stock_remaining

2. Loki용 비즈니스 로그 추가 (신청-대기열 핵심 흐름)
- [QUEUE] — 대기열 진입, 통과 확인, 이탈, 배치 처리, 토큰 발급
- [ENTRY] — 사전정보 저장·삭제, 신청, 추첨·선착순 결과, 결제 확정
- [STOCK] — 재고 초기화, 선점 결과, 확정, 복원, 조회


QueueBatchScheduler, EventStockService 메트릭 로직을 전담 클래스로 위임

## 📸 스크린샷 / 아키텍처 / 로그 (필수)
1. Queue 비즈니스 로그 출력 확인 (Docker)
[QUEUE] 대기열 진입 userId=1, paceId=10, position=1
[QUEUE] 통과 토큰 발급 userId=1, paceId=10
[QUEUE] 배치 처리 완료 paceId=10, issued=1, waiting=0
[QUEUE] 통과 확인 userId=1, paceId=10
[QUEUE] 대기열 이탈 userId=1, paceId=10
Loki 적재 확인

-> LogQL {container="on-race-queue"} |= "[QUEUE]" → 5건 정상 적재 확인 완료

2. 선착순 사용자 여정 로그 흐름
[queue]  [QUEUE] 대기열 진입 userId=42, paceId=5, position=128
[queue]  [QUEUE] 통과 토큰 발급 userId=42, paceId=5
[queue]  [QUEUE] 통과 확인 userId=42, paceId=5
[main]   [ENTRY] 신청 시작 userId=42, eventId=1, appType=FIRST_COME, courseId=3, paceId=5
[main]   [STOCK] 재고 선점 paceId=5, userId=42, result=성공(남은:87)
[main]   [ENTRY] 선착순 선점 성공 userId=42, paceId=5, remaining=87
[main]   [ENTRY] 결제 확정 userId=42, paceId=5, appType=FIRST_COME
[main]   [STOCK] 재고 확정 paceId=5

## ❓ 변경 이유 (Why)
기존 @ApiLog/@ServiceLog는 요청 타이밍만 기록하여 비즈니스 컨텍스트(누가, 어떤 페이스에, 무슨 결과)가 로그에 남지 않았음
Grafana 대시보드에서 사용자 여정 추적, 장애 분석, 트래픽 패턴 분석이 불가능한 상태
메트릭 코드가 서비스 로직에 인라인으로 흩어져 있어 관심사 분리 필요
Loki + Prometheus 기반 관측성(Observability) 체계 구축

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
