### PR TITLE
feat(backend): 서비스 간 traceId 컨텍스트 전파 구현

### DIFF
--- a/backend/auth/src/main/java/com/kt/onrace/auth/common/client/FeignGatewayInterceptorConfig.java
+++ b/backend/auth/src/main/java/com/kt/onrace/auth/common/client/FeignGatewayInterceptorConfig.java
@@ -3,8 +3,9 @@ package com.kt.onrace.auth.common.client;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 
+import com.kt.onrace.common.logging.helper.TraceIdPropagation;
+
 import feign.RequestInterceptor;
-import feign.RequestTemplate;
 
 public class FeignGatewayInterceptorConfig {
 
@@ -13,11 +14,10 @@ public class FeignGatewayInterceptorConfig {
 
 	@Bean
 	public RequestInterceptor requestInterceptor() {
-		return new RequestInterceptor() {
-			@Override
-			public void apply(RequestTemplate requestTemplate) {
-				requestTemplate.header("X-Gateway-Token", gatewaySecret);
-			}
+		return requestTemplate -> {
+			requestTemplate.header("X-Gateway-Token", gatewaySecret);
+			TraceIdPropagation.setTraceHeader(
+				(name, value) -> requestTemplate.header(name, value));
 		};
 	}
 

--- a/backend/common/src/main/java/com/kt/onrace/common/config/ContextPropagationConfig.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/config/ContextPropagationConfig.java
@@ -4,6 +4,8 @@ import org.slf4j.MDC;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.kt.onrace.common.logging.helper.TraceIdGenerator;
+
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ThreadLocalAccessor;
 
@@ -15,7 +17,7 @@ public class ContextPropagationConfig {
 		ContextRegistry registry = ContextRegistry.getInstance();
 
 		registry.registerThreadLocalAccessor(new ThreadLocalAccessor<String>() {
-			private static final String KEY = "traceId";
+			private static final String KEY = TraceIdGenerator.TRACE_ID_MDC_KEY;
 
 			@Override
 			public Object key() {

--- a/backend/common/src/main/java/com/kt/onrace/common/config/TraceIdClientConfig.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/config/TraceIdClientConfig.java
@@ -1,0 +1,23 @@
+package com.kt.onrace.common.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.kt.onrace.common.logging.helper.TraceIdPropagation;
+
+@Configuration
+public class TraceIdClientConfig {
+
+	@Configuration
+	@ConditionalOnClass(name = "org.springframework.web.client.RestClient")
+	static class RestClientTraceConfig {
+
+		@Bean
+		RestClientCustomizer traceIdRestClientCustomizer() {
+			return builder -> builder.requestInterceptor(
+				TraceIdPropagation.restClientInterceptor());
+		}
+	}
+}

--- a/backend/common/src/main/java/com/kt/onrace/common/config/TraceIdClientConfig.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/config/TraceIdClientConfig.java
@@ -8,16 +8,12 @@ import org.springframework.context.annotation.Configuration;
 import com.kt.onrace.common.logging.helper.TraceIdPropagation;
 
 @Configuration
+@ConditionalOnClass(name = "org.springframework.web.client.RestClient")
 public class TraceIdClientConfig {
 
-	@Configuration
-	@ConditionalOnClass(name = "org.springframework.web.client.RestClient")
-	static class RestClientTraceConfig {
-
-		@Bean
-		RestClientCustomizer traceIdRestClientCustomizer() {
-			return builder -> builder.requestInterceptor(
-				TraceIdPropagation.restClientInterceptor());
-		}
+	@Bean
+	RestClientCustomizer traceIdRestClientCustomizer() {
+		return builder -> builder.requestInterceptor(
+			TraceIdPropagation.restClientInterceptor());
 	}
 }

--- a/backend/common/src/main/java/com/kt/onrace/common/logging/helper/TraceIdGenerator.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/logging/helper/TraceIdGenerator.java
@@ -8,8 +8,8 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public class TraceIdGenerator {
 
-	private static final String TRACE_ID_HEADER = "X-Trace-Id";
-	private static final String TRACE_ID_MDC_KEY = "traceId";
+	public static final String TRACE_ID_HEADER = "X-Trace-Id";
+	public static final String TRACE_ID_MDC_KEY = "traceId";
 
 	public static void getOrCreateTraceId(HttpServletRequest request) {
 		String traceId = request.getHeader(TRACE_ID_HEADER);
@@ -19,6 +19,10 @@ public class TraceIdGenerator {
 		}
 
 		MDC.put(TRACE_ID_MDC_KEY, traceId);
+	}
+
+	public static String getCurrentTraceId() {
+		return MDC.get(TRACE_ID_MDC_KEY);
 	}
 
 	private static String generateTraceId() {

--- a/backend/common/src/main/java/com/kt/onrace/common/logging/helper/TraceIdPropagation.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/logging/helper/TraceIdPropagation.java
@@ -1,0 +1,30 @@
+package com.kt.onrace.common.logging.helper;
+
+import java.util.function.BiConsumer;
+
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+
+public final class TraceIdPropagation {
+
+	private TraceIdPropagation() {
+	}
+
+	// MDC에서 traceId를 읽어 헤더로 전파 — Servlet 기반 HTTP 클라이언트용
+	public static void setTraceHeader(BiConsumer<String, String> headerSetter) {
+		String traceId = TraceIdGenerator.getCurrentTraceId();
+		if (traceId != null && !traceId.isEmpty()) {
+			headerSetter.accept(TraceIdGenerator.TRACE_ID_HEADER, traceId);
+		}
+	}
+
+	// MDC에서 traceId를 읽어 X-Trace-Id 헤더로 전파하는 RestClient 인터셉터
+	public static ClientHttpRequestInterceptor restClientInterceptor() {
+		return (request, body, execution) -> {
+			String traceId = TraceIdGenerator.getCurrentTraceId();
+			if (traceId != null && !traceId.isEmpty()) {
+				request.getHeaders().set(TraceIdGenerator.TRACE_ID_HEADER, traceId);
+			}
+			return execution.execute(request, body);
+		};
+	}
+}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -87,6 +87,7 @@ services:
     environment:
       - MAIN_DB_HOST=main-mysql
       - MAIN_REDIS_HOST=main-redis
+      - AUTH_SERVICE_URI=http://auth:${AUTH_SERVER_PORT}
     depends_on:
       - main-mysql
       - main-redis

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/cache/QueueEventCache.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/cache/QueueEventCache.java
@@ -16,6 +16,7 @@ import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.kt.onrace.common.logging.helper.TraceIdGenerator;
 import com.kt.onrace.common.util.RedisKeyGenerator;
 import com.kt.onrace.gateway.config.GatewayProperties;
 
@@ -94,9 +95,9 @@ public class QueueEventCache {
 	// Reactor Context에서 traceId를 읽어 X-Trace-Id 헤더로 전파하는 WebClient 필터
 	private static ExchangeFilterFunction traceIdFilter() {
 		return (request, next) -> Mono.deferContextual(ctx -> {
-			if (ctx.hasKey("traceId")) {
+			if (ctx.hasKey(TraceIdGenerator.TRACE_ID_MDC_KEY)) {
 				ClientRequest mutated = ClientRequest.from(request)
-					.header("X-Trace-Id", ctx.<String>get("traceId"))
+					.header(TraceIdGenerator.TRACE_ID_HEADER, ctx.<String>get(TraceIdGenerator.TRACE_ID_MDC_KEY))
 					.build();
 				return next.exchange(mutated);
 			}

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/cache/QueueEventCache.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/cache/QueueEventCache.java
@@ -11,6 +11,8 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -38,6 +40,7 @@ public class QueueEventCache {
 		this.webClient = WebClient.builder()
 			.baseUrl(queueCache.getServiceUri())
 			.defaultHeader("X-Gateway-Token", gatewayProperties.getInternal().getSecret())
+			.filter(traceIdFilter())
 			.build();
 		this.redissonClient = redissonClient;
 	}
@@ -86,6 +89,19 @@ public class QueueEventCache {
 
 	public boolean isQueueEnabled(Long eventId) {
 		return enabledEventIds.contains(eventId);
+	}
+
+	// Reactor Context에서 traceId를 읽어 X-Trace-Id 헤더로 전파하는 WebClient 필터
+	private static ExchangeFilterFunction traceIdFilter() {
+		return (request, next) -> Mono.deferContextual(ctx -> {
+			if (ctx.hasKey("traceId")) {
+				ClientRequest mutated = ClientRequest.from(request)
+					.header("X-Trace-Id", ctx.<String>get("traceId"))
+					.build();
+				return next.exchange(mutated);
+			}
+			return next.exchange(request);
+		});
 	}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)

--- a/backend/main/src/main/java/com/kt/onrace/domain/mypage/client/HttpAuthAccountClient.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/mypage/client/HttpAuthAccountClient.java
@@ -24,10 +24,12 @@ public class HttpAuthAccountClient implements AuthAccountClient {
 
 	public HttpAuthAccountClient(
 		RestClient.Builder restClientBuilder,
-		@Value("${api.url.auth}") String authServiceUrl
+		@Value("${api.url.auth}") String authServiceUrl,
+		@Value("${gateway.internal.secret}") String gatewaySecret
 	) {
 		this.restClient = restClientBuilder
 			.baseUrl(authServiceUrl)
+			.defaultHeader("X-Gateway-Token", gatewaySecret)
 			.build();
 	}
 


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- 서비스 간 HTTP 호출 시 X-Trace-Id 헤더를 자동 전파하도록 구현
- TraceIdPropagation 유틸리티 추가 (RestClient 인터셉터, BiConsumer 기반 범용 헤더 세팅)
- TraceIdClientConfig 추가 — RestClientCustomizer로 모든 RestClient.Builder에 traceId 인터셉터 자동 적용
- TraceIdGenerator 상수(TRACE_ID_HEADER, TRACE_ID_MDC_KEY) public 전환 및 getCurrentTraceId() 메서드 추가
- ContextPropagationConfig에서 리터럴 대신 TraceIdGenerator 상수 참조로 변경
- FeignGatewayInterceptorConfig에 traceId 전파 추가 (Auth → Main Feign 호출 시)
- QueueEventCache에 WebClient traceId 필터 추가 (Gateway → Queue 호출 시, Reactor Context 기반)
- HttpAuthAccountClient에 X-Gateway-Token 헤더 추가 및 RestClient.Builder 주입 방식으로 traceId 자동 전파
- docker-compose.yml에 main 서비스 AUTH_SERVICE_URI 환경변수 추가

## 📸 스크린샷 / 아키텍처 / 로그 (필수)

- UI 변경 시 스크린샷 첨부 (Frontend 필수)
- 로직 변경 시 관련 로그나 다이어그램, 테스트 결과 캡처 첨부 (Backend/Infra 필수)
- _멘토링 피드백: "글보다 그림/화면으로 소통하세요"_

## ❓ 변경 이유 (Why)
- 기존에는 Gateway에서 생성한 traceId가 각 모듈까지는 전달되었지만, 모듈 간 HTTP 호출(Feign, RestClient, WebClient) 시 traceId가 전파되지 않아 새로운 traceId가 생성되었음
- 이로 인해 하나의 사용자 요청이 여러 서비스를 거칠 때 전체 흐름을 하나의 traceId로 추적할 수 없었음
- 본 변경으로 Gateway → Main → Auth 등 서비스 간 호출 시 동일 traceId가 유지되어, Loki/Grafana에서 단일 traceId로 전체 요청 흐름을 추적 가능

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
