### PR TITLE
feat(backend): k6 부하테스트 인프라 고도화 및 기획 시나리오 지원

### DIFF
--- a/backend/auth/src/main/resources/application.yml
+++ b/backend/auth/src/main/resources/application.yml
@@ -28,6 +28,14 @@ spring:
     username: ${AUTH_DB_USERNAME}
     password: ${AUTH_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      # Auth는 로그인/회원가입 등 인증 위주 → Main 대비 DB 쿼리 빈도 낮음
+      # Main의 60~70% 수준으로 설정. 상세 설명은 main application.yml 참고
+      maximum-pool-size: ${AUTH_HIKARI_MAX_POOL_SIZE:10}
+      minimum-idle: ${AUTH_HIKARI_MIN_IDLE:5}
+      connection-timeout: ${AUTH_HIKARI_CONNECTION_TIMEOUT:3000}
+      max-lifetime: ${AUTH_HIKARI_MAX_LIFETIME:1800000}
+      idle-timeout: ${AUTH_HIKARI_IDLE_TIMEOUT:600000}
 
   jpa:
     hibernate:
@@ -77,6 +85,14 @@ spring:
 server:
   port: ${AUTH_SERVER_PORT:8081}
   forward-headers-strategy: framework
+  tomcat:
+    threads:
+      # Auth 트래픽은 Main의 30~50% 수준 (로그인, 토큰 갱신 등)
+      # 상세 설명은 main application.yml 참고
+      max: ${AUTH_TOMCAT_MAX_THREADS:200}
+      min-spare: ${AUTH_TOMCAT_MIN_SPARE_THREADS:30}
+    accept-count: ${AUTH_TOMCAT_ACCEPT_COUNT:100}
+    # [AWS 배포 시] Auth는 Main 대비 트래픽 비중 낮음. Main의 60~70% 수준 권장
 
 jwt:
   secret: ${JWT_SECRET}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,6 +10,17 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      # max_connections: MySQL이 허용하는 최대 동시 연결 수
+      # 범위: 100~10000 | 기준: 모든 앱 인스턴스의 HikariCP pool 합 + 여유분(모니터링, 관리 연결)
+      # 현재: Main(50) + Auth(30) = 80 → 500이면 충분한 여유
+      # [AWS 배포 시] RDS 인스턴스 클래스별 자동 계산됨 (t3.medium: ~312, r5.large: ~1365)
+      - --max_connections=500
+      # innodb_buffer_pool_size: InnoDB 데이터+인덱스 캐시 메모리
+      # 범위: 128M~시스템 메모리의 70% | 기준: 테이블 데이터 크기
+      # 클수록 디스크 I/O 감소 → 쿼리 성능 향상
+      # 로컬 Docker: 512M~2G, 서버: 전체 메모리의 50~70%
+      # 현재 Docker 메모리 31GB, MySQL 사용 ~500MB → 2G 할당 가능 (여유 충분)
+      - --innodb_buffer_pool_size=2G
     volumes:
       - main-db-data:/var/lib/mysql
     networks:

--- a/backend/gateway/src/main/java/com/kt/onrace/gateway/config/SecurityConfig.java
+++ b/backend/gateway/src/main/java/com/kt/onrace/gateway/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
 				.pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
 				.pathMatchers("/auth/**").permitAll()
 				.pathMatchers("/main/**").permitAll()
+				.pathMatchers("/queue/**").permitAll()
 				.pathMatchers("/actuator/**").permitAll()
 				.anyExchange().authenticated()
 			)

--- a/backend/gateway/src/main/resources/application.yml
+++ b/backend/gateway/src/main/resources/application.yml
@@ -1,5 +1,17 @@
 server:
   port: ${GATEWAY_SERVER_PORT:8080}
+  # ──── Gateway 성능 튜닝 가이드 (WebFlux/Netty 기반) ────
+  # Gateway는 Tomcat이 아닌 Netty 사용 → threads 설정 불필요
+  # Netty 워커 스레드: 기본 CPU 코어 x 2 (자동 설정)
+  #
+  # [AWS 배포 시] 고트래픽 환경에서 워커 스레드 수동 조정:
+  #   JVM_OPTS에 -Dreactor.netty.ioWorkerCount=32 추가 (기본: 코어 x 2)
+  #   K8s Pod CPU 2코어 기본 4개 → 16~32 권장
+  #
+  # [AWS 배포 시] Rate Limiter 활성화:
+  #   현재 auth-route, queue-route, entry-apply 라우트의 RateLimiter가 주석 처리됨
+  #   운영 시 반드시 활성화 (매크로 방어)
+  #   replenishRate: 초당 허용 요청 수 | burstCapacity: 순간 허용 최대 요청 수
 
 spring:
   application:
@@ -45,26 +57,26 @@ spring:
               filters:
                 - StripPrefix=1
                 - SetRequestHeader=X-Forwarded-Prefix, /auth
-                - name: RequestRateLimiter
-                  args:
-                    redis-rate-limiter.replenishRate: 50
-                    redis-rate-limiter.burstCapacity: 100
-                    redis-rate-limiter.requestedTokens: 1
-                    key-resolver: "#{@userOrIpKeyResolver}"
-            #            - id: queue-route
-            #              uri: ${QUEUE_SERVICE_URI:http://localhost:8083}
-            #              predicates:
-            #                - Path=/queue/**
-            #              filters:
-            #                - name: BotDetectionFilter
-            #                  args:
-            #                    challengeUri: ${CHALLENGE_URI:http://localhost:3000/challenge}
-            #                - name: RequestRateLimiter
-            #                  args:
-            #                    redis-rate-limiter.replenishRate: 50
-            #                    redis-rate-limiter.burstCapacity: 100
-            #                    redis-rate-limiter.requestedTokens: 1
-            #                    key-resolver: "#{@userOrIpKeyResolver}"
+#                - name: RequestRateLimiter
+#                  args:
+#                    redis-rate-limiter.replenishRate: 50
+#                    redis-rate-limiter.burstCapacity: 100
+#                    redis-rate-limiter.requestedTokens: 1
+#                    key-resolver: "#{@userOrIpKeyResolver}"
+            - id: queue-route
+              uri: ${QUEUE_SERVICE_URI:http://localhost:8083}
+              predicates:
+                - Path=/queue/**
+              filters:
+#                - name: BotDetectionFilter
+#                  args:
+#                    challengeUri: ${CHALLENGE_URI:http://localhost:3000/challenge}
+#                - name: RequestRateLimiter
+#                  args:
+#                    redis-rate-limiter.replenishRate: 50
+#                    redis-rate-limiter.burstCapacity: 100
+#                    redis-rate-limiter.requestedTokens: 1
+#                    key-resolver: "#{@userOrIpKeyResolver}"
             - id: entry-apply-lottery-route
               uri: ${MAIN_SERVICE_URI:http://localhost:8082}
               predicates:
@@ -72,31 +84,31 @@ spring:
               filters:
                 - StripPrefix=1
                 - SetRequestHeader=X-Forwarded-Prefix, /main
-                - name: RequestRateLimiter
+#                - name: RequestRateLimiter
+#                  args:
+#                    redis-rate-limiter.replenishRate: 10
+#                    redis-rate-limiter.burstCapacity: 20
+#                    redis-rate-limiter.requestedTokens: 1
+#                    key-resolver: "#{@userOrIpKeyResolver}"
+            - id: entry-apply-first-come-route
+              uri: ${MAIN_SERVICE_URI:http://localhost:8082}
+              predicates:
+                - Path=/main/events/*/entries/apply/first-come
+              filters:
+                - StripPrefix=1
+                - SetRequestHeader=X-Forwarded-Prefix, /main
+#                - name: RequestRateLimiter
+#                  args:
+#                    redis-rate-limiter.replenishRate: 10
+#                    redis-rate-limiter.burstCapacity: 20
+#                    redis-rate-limiter.requestedTokens: 1
+#                    key-resolver: "#{@userOrIpKeyResolver}"
+#                - name: BotDetectionFilter
+#                  args:
+#                    challengeUri: ${CHALLENGE_URI:http://localhost:3000/challenge}
+                - name: WaitingRoomFilter
                   args:
-                    redis-rate-limiter.replenishRate: 10
-                    redis-rate-limiter.burstCapacity: 20
-                    redis-rate-limiter.requestedTokens: 1
-                    key-resolver: "#{@userOrIpKeyResolver}"
-            #            - id: entry-apply-first-come-route
-            #              uri: ${MAIN_SERVICE_URI:http://localhost:8082}
-            #              predicates:
-            #                - Path=/main/events/*/entries/apply/first-come
-            #              filters:
-            #                - StripPrefix=1
-            #                - SetRequestHeader=X-Forwarded-Prefix, /main
-            #                - name: RequestRateLimiter
-            #                  args:
-            #                    redis-rate-limiter.replenishRate: 10
-            #                    redis-rate-limiter.burstCapacity: 20
-            #                    redis-rate-limiter.requestedTokens: 1
-            #                    key-resolver: "#{@userOrIpKeyResolver}"
-            #                - name: BotDetectionFilter
-            #                  args:
-            #                    challengeUri: ${CHALLENGE_URI:http://localhost:3000/challenge}
-            #                - name: WaitingRoomFilter
-            #                  args:
-            #                    queueUrl: ${WAITING_ROOM_URI:http://localhost:3000/queue}
+                    queueUrl: ${WAITING_ROOM_URI:http://localhost:3000/queue}
             - id: stock-check-route
               uri: ${MAIN_SERVICE_URI:http://localhost:8082}
               predicates:

--- a/backend/k6/README.md
+++ b/backend/k6/README.md
@@ -1,0 +1,287 @@
+# k6 부하 테스트
+
+On-Race 마라톤 이벤트 티켓팅 플랫폼 부하 테스트 스크립트.
+
+## 테스트 시나리오
+
+| # | 시나리오 | 스크립트 | 설명 |
+|---|---------|---------|------|
+| 0 | 스모크 테스트 | `00-smoke-test.js` | 환경 검증 (5 VU) |
+| 1 | 응모신청 | `01-lottery.js` | 로그인 → 응모 (전원 성공) |
+| 2 | 선착순 대기열X | `02-first-come-no-queue.js` | 로그인 → 선착순 (재고 소진 시 매진) |
+| 3 | 선착순 대기열O | `03-first-come-with-queue.js` | 로그인 → 대기열 → 폴링 → 선착순 |
+
+## 테스트 조건
+
+### 소규모 (기본)
+- **재고**: 15페이스 x 100석 = 1,500석/이벤트 (`setup-load-test-events.sql`)
+- **유저**: 4,500명 (경쟁률 3:1)
+
+### 대규모
+- **재고**: 15페이스 x 667석 = ~10,000석/이벤트 (`setup-load-test-events-large.sql`)
+- **유저**: 최대 30,000명 (경쟁률 3:1)
+
+### 공통
+- **배분**: 70% HOT 페이스 집중, 30% 나머지 14개 분산
+- **Gateway 경유**: JWT 인증 + 큐 토큰 검증 활성화, 봇 토큰/Rate Limit 비활성화
+
+## 사전 준비
+
+### 1. k6 설치
+
+```bash
+# Windows
+winget install grafana.k6
+
+# macOS
+brew install k6
+
+# 확인
+k6 version
+```
+
+### 2. Gateway 설정 변경
+
+`gateway/src/main/resources/application.yml`에서:
+
+1. **auth-route**: `RequestRateLimiter` 주석 처리 (IP 기반 rate limit 제거)
+2. **queue-route**: 주석 해제, BotDetectionFilter 주석 유지
+3. **entry-apply-first-come-route**: 주석 해제, BotDetectionFilter 주석 유지
+
+### 3. 서비스 기동
+
+```bash
+# Docker로 전체 기동
+docker-compose up -d --build
+
+# 또는 개별 실행
+# Gateway(30000), Auth(31000), Main(32000), Queue(33000), MySQL, Redis
+```
+
+### 4. 데이터 셋업
+
+#### 방법 A: API 자동 셋업 (권장)
+
+k6 시나리오 스크립트(00~03)는 `setup()` 단계에서 아래 API를 자동 호출합니다.
+별도 SQL 실행이나 Redis 초기화가 **필요 없습니다**.
+
+```bash
+# 수동으로 확인하려면:
+curl -X POST http://localhost:30000/main/internal/load-test/setup \
+  -H 'Content-Type: application/json' \
+  -d '{"stockPerPace": 100}'
+```
+
+이 API는 유저 3만명 등록(멱등) → 이전 데이터 정리 → 이벤트/코스/페이스/재고/판매정보 생성 → Redis flushDB + 재고 초기화 + 대기열 활성화를 한 번에 수행합니다.
+`local` 프로필에서만 활성화됩니다.
+
+#### 방법 B: SQL 수동 실행 (레거시)
+
+API를 사용하지 않고 직접 SQL을 실행하는 경우:
+
+```bash
+# 유저 데이터 (30,000명)
+mysql -u root -p on-race-main < k6/data/setup-load-test-users.sql
+
+# 이벤트 데이터 (소규모: 100석/페이스)
+mysql -u root -p on-race-main < k6/data/setup-load-test-events.sql
+
+# 이벤트 데이터 (대규모: 667석/페이스) — 10K+ VU 테스트 시
+# mysql -u root -p on-race-main < k6/data/setup-load-test-events-large.sql
+```
+
+### 5. Redis 재고 초기화 (SQL 수동 실행 시만)
+
+API 셋업 사용 시 자동 처리됩니다. SQL 수동 실행 시에만 필요합니다.
+
+```bash
+curl -X POST http://localhost:30000/main/events/11/stock/init
+curl -X POST http://localhost:30000/main/events/12/stock/init
+curl -X POST http://localhost:30000/main/events/13/stock/init
+```
+
+### 6. 대기열 활성화 (SQL 수동 실행 + 시나리오 3만)
+
+API 셋업 사용 시 자동 처리됩니다.
+
+```bash
+curl -X POST http://localhost:30000/main/events/13/queue/enable
+```
+
+## 실행
+
+### Phase 1: 스모크 테스트
+
+```bash
+k6 run k6/scenarios/00-smoke-test.js
+```
+
+### Phase 2: 소규모 검증 (50~100 VU)
+
+```bash
+k6 run -e VU_COUNT=50 k6/scenarios/01-lottery.js
+# cleanup 후 →
+k6 run -e VU_COUNT=50 k6/scenarios/02-first-come-no-queue.js
+# cleanup 후 →
+k6 run -e VU_COUNT=50 k6/scenarios/03-first-come-with-queue.js
+```
+
+### Phase 3: 기획 목표 (4,500 VU, 1,500석)
+
+```bash
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 k6/scenarios/01-lottery.js
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 k6/scenarios/02-first-come-no-queue.js
+k6 run -e VU_COUNT=3800 -e RAMP_UP_SEC=60 -e HOLD_SEC=300 k6/scenarios/03-first-come-with-queue.js
+```
+
+### Phase 4: 대규모 (10,000~15,000 VU, 10,000석)
+
+```bash
+# 대규모 이벤트 데이터로 교체
+mysql -u root -p on-race-main < k6/data/setup-load-test-events-large.sql
+
+# .env에서 HIKARI 풀 50, 서비스 재시작 후
+k6 run -e VU_COUNT=10000 -e RAMP_UP_SEC=120 -e HOLD_SEC=300 k6/scenarios/02-first-come-no-queue.js
+```
+
+### Phase 5: 최대 스케일 (30,000 VU)
+
+```bash
+k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e LOGIN_TIMEOUT=180s \
+  k6/scenarios/02-first-come-no-queue.js
+```
+
+### Prometheus 연동
+
+```bash
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
+k6 run -o experimental-prometheus-rw -e VU_COUNT=4500 k6/scenarios/01-lottery.js
+```
+
+## 환경변수
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `BASE_URL` | `http://localhost:30000` | Gateway 주소 |
+| `VU_COUNT` | `100` | 동시 사용자 수 (최대 30,000) |
+| `USER_PASSWORD` | `Test1234!@` | 테스트 유저 비밀번호 |
+| `LOGIN_TIMEOUT` | `120s` | 로그인 HTTP 타임아웃 |
+| `HOT_PACE_RATIO` | `0.7` | HOT 페이스 집중 비율 |
+| `RAMP_UP_SEC` | `10` | 램프업 시간(초) |
+| `HOLD_SEC` | `120` | 유지 시간(초) |
+| `RAMP_DOWN_SEC` | `5` | 램프다운 시간(초) |
+| `QUEUE_POLL_SEC` | `2` | 대기열 폴링 간격(초) |
+| `QUEUE_MAX_POLL` | `300` | 최대 폴링 횟수 |
+| `EVENT_LOTTERY` | `11` | 응모 이벤트 ID |
+| `EVENT_FC_NO_QUEUE` | `12` | 선착순(대기열X) 이벤트 ID |
+| `EVENT_FC_WITH_QUEUE` | `13` | 선착순(대기열O) 이벤트 ID |
+| `HOT_COURSE_ID` | (자동) | HOT 코스 ID (오버라이드) |
+| `HOT_PACE_ID` | (자동) | HOT 페이스 ID (오버라이드) |
+| `OTHER_PACES` | (자동) | 기타 페이스 JSON (오버라이드) |
+
+## ID 체계
+
+### API 셋업 사용 시 (권장)
+
+`POST /main/internal/load-test/setup` API를 통해 데이터를 셋업하면 **auto_increment로 ID가 동적 할당**됩니다.
+k6 시나리오 스크립트(01~03)는 setup 응답의 `eventIds`와 `paceMap`을 사용하므로 고정 ID에 의존하지 않습니다.
+
+### SQL 수동 실행 시 (레거시)
+
+아래 고정 ID는 `k6/data/*.sql` 파일을 직접 실행할 때만 해당됩니다.
+
+| 구분 | ID 범위 | 비고 |
+|------|---------|------|
+| 유저 | 10001~40000 | k6user00001~k6user30000 |
+| 이벤트 11 | 코스 31-33, 페이스 151-165 | 응모, HOT=162 |
+| 이벤트 12 | 코스 34-36, 페이스 166-180 | 선착순(대기열X), HOT=177 |
+| 이벤트 13 | 코스 37-39, 페이스 181-195 | 선착순(대기열O), HOT=192 |
+
+## 테스트 간 초기화
+
+시나리오 재실행 전 반드시:
+
+```bash
+# 1. SQL 초기화 (entry 삭제 + stock 리셋)
+mysql -u root -p on-race-main < k6/data/cleanup-between-tests.sql
+
+# 2. Redis 재고 초기화
+curl -X POST http://localhost:30000/main/events/11/stock/init
+curl -X POST http://localhost:30000/main/events/12/stock/init
+curl -X POST http://localhost:30000/main/events/13/stock/init
+
+# 3. 대기열 재활성화 (시나리오 3)
+curl -X POST http://localhost:30000/main/events/13/queue/enable
+```
+
+## 기대 결과
+
+### 시나리오 1: 응모신청
+
+| 항목 | 기대값 (4,500 VU) |
+|------|-------------------|
+| 응모 성공 | VU_COUNT건 (전원 200) |
+| DB entry | VU_COUNT건 (status=APPLIED) |
+| p95 응답시간 | < 3초 |
+
+### 시나리오 2: 선착순 대기열X
+
+| 항목 | 기대값 (4,500 VU / 1,500석) |
+|------|----------------------------|
+| 선점 성공 (200) | ~1,500건 |
+| 매진 응답 (400) | ~3,000건 |
+| 오버셀링 | **0건** |
+| p95 응답시간 | < 3초 |
+
+### 시나리오 3: 선착순 대기열O
+
+| 항목 | 기대값 (4,500 VU / 1,500석) |
+|------|----------------------------|
+| PASS 수신 | 전원 |
+| 선점 성공 (200) | ~1,500건 |
+| 매진 응답 (400) | ~2,300건 |
+| 오버셀링 | **0건** |
+| queue_wait_time p95 | < 5분 |
+
+## 검증 쿼리
+
+```sql
+-- 오버셀링 확인 (entry 수 <= stock 수)
+SELECT ep.id AS pace_id, ep.name,
+  es.total_stock,
+  COUNT(e.id) AS entry_count,
+  CASE WHEN COUNT(e.id) > es.total_stock THEN 'OVERSOLD!' ELSE 'OK' END AS status
+FROM event_pace ep
+JOIN event_stock es ON es.event_pace_id = ep.id
+LEFT JOIN entry e ON e.event_pace_id = ep.id AND e.status IN ('RESERVED', 'APPLIED')
+WHERE ep.id BETWEEN 151 AND 195
+GROUP BY ep.id, ep.name, es.total_stock;
+
+-- 이벤트별 entry 집계
+SELECT e.event_id, COUNT(*) AS total,
+  SUM(CASE WHEN e.status = 'APPLIED' THEN 1 ELSE 0 END) AS applied,
+  SUM(CASE WHEN e.status = 'RESERVED' THEN 1 ELSE 0 END) AS reserved
+FROM entry e
+WHERE e.user_id BETWEEN 10001 AND 40000
+GROUP BY e.event_id;
+
+-- 중복 entry 검증
+SELECT user_id, event_id, COUNT(*) AS cnt
+FROM entry WHERE user_id BETWEEN 10001 AND 40000
+GROUP BY user_id, event_id HAVING cnt > 1;
+```
+
+## 커스텀 메트릭
+
+| 시나리오 | 메트릭 | 타입 | 설명 |
+|---------|--------|------|------|
+| 01 | `lottery_apply_success` | Counter | 응모 성공 수 |
+| 01 | `lottery_apply_fail` | Counter | 응모 실패 수 |
+| 02 | `firstcome_reserve_success` | Counter | 선점 성공 수 |
+| 02 | `firstcome_sold_out` | Counter | 매진 응답 수 |
+| 02 | `firstcome_unexpected_error` | Counter | 예상 외 에러 수 |
+| 03 | `queue_wait_time` | Trend | 대기열 대기 시간(ms) |
+| 03 | `queue_pass_count` | Counter | PASS 수신 수 |
+| 03 | `queue_timeout_count` | Counter | 대기열 타임아웃 수 |
+| 03 | `queue_reserve_success` | Counter | 선점 성공 수 |
+| 03 | `queue_sold_out` | Counter | 매진 응답 수 |

--- a/backend/k6/README.md
+++ b/backend/k6/README.md
@@ -1,33 +1,106 @@
-# k6 부하 테스트
+# k6 부하 테스트 가이드
 
-On-Race 마라톤 이벤트 티켓팅 플랫폼 부하 테스트 스크립트.
+On-Race 마라톤 이벤트 티켓팅 플랫폼 부하 테스트 문서입니다.
+**데이터 셋업부터 Redis 초기화, 대기열 활성화까지 모두 자동화**되어 있으므로, k6 명령어 한 줄로 테스트를 실행할 수 있습니다.
 
-## 테스트 시나리오
+---
+
+## 목차
+
+1. [테스트 시나리오 개요](#1-테스트-시나리오-개요)
+2. [아키텍처 & 테스트 흐름](#2-아키텍처--테스트-흐름)
+3. [사전 준비](#3-사전-준비)
+4. [실행 방법](#4-실행-방법)
+5. [환경변수 레퍼런스](#5-환경변수-레퍼런스)
+6. [시나리오별 실행 예시](#6-시나리오별-실행-예시)
+7. [모니터링 (Prometheus + Grafana)](#7-모니터링-prometheus--grafana)
+8. [결과 검증](#8-결과-검증)
+9. [커스텀 메트릭 레퍼런스](#9-커스텀-메트릭-레퍼런스)
+10. [트러블슈팅](#10-트러블슈팅)
+
+---
+
+## 1. 테스트 시나리오 개요
 
 | # | 시나리오 | 스크립트 | 설명 |
 |---|---------|---------|------|
-| 0 | 스모크 테스트 | `00-smoke-test.js` | 환경 검증 (5 VU) |
-| 1 | 응모신청 | `01-lottery.js` | 로그인 → 응모 (전원 성공) |
-| 2 | 선착순 대기열X | `02-first-come-no-queue.js` | 로그인 → 선착순 (재고 소진 시 매진) |
-| 3 | 선착순 대기열O | `03-first-come-with-queue.js` | 로그인 → 대기열 → 폴링 → 선착순 |
+| 0 | 스모크 테스트 | `00-smoke-test.js` | 환경 검증 (5 VU, 전체 이벤트 생성) |
+| 1 | 응모신청 | `01-lottery.js` | 로그인 → 응모 (재고 무제한, 전원 성공) |
+| 2 | 선착순 대기열X | `02-first-come-no-queue.js` | 로그인 → 선착순 → 결제/이탈 → Wave2 재선점 |
+| 3 | 선착순 대기열O | `03-first-come-with-queue.js` | 로그인 → 대기열 → 선착순 → 결제/이탈 → Wave2 재선점 |
 
-## 테스트 조건
+> **시나리오별 단일 이벤트 생성**: 각 시나리오는 자신에 해당하는 이벤트 **1개만** 생성합니다.
+> 예: `01-lottery.js`는 응모 이벤트 1개만, `02-first-come-no-queue.js`는 선착순(대기열X) 이벤트 1개만 생성합니다.
 
-### 소규모 (기본)
-- **재고**: 15페이스 x 100석 = 1,500석/이벤트 (`setup-load-test-events.sql`)
-- **유저**: 4,500명 (경쟁률 3:1)
+---
 
-### 대규모
-- **재고**: 15페이스 x 667석 = ~10,000석/이벤트 (`setup-load-test-events-large.sql`)
-- **유저**: 최대 30,000명 (경쟁률 3:1)
+## 2. 아키텍처 & 테스트 흐름
 
-### 공통
-- **배분**: 70% HOT 페이스 집중, 30% 나머지 14개 분산
-- **Gateway 경유**: JWT 인증 + 큐 토큰 검증 활성화, 봇 토큰/Rate Limit 비활성화
+### 2.1 자동 셋업 (Setup API)
 
-## 사전 준비
+```
+k6 setup() 단계
+  ↓
+POST /main/internal/load-test/setup  (scenarioType 지정)
+  ↓
+┌─────────────────────────────────────────┐
+│ 1. 유저 30,000명 등록 (멱등)             │
+│ 2. 이전 테스트 데이터 정리               │
+│ 3. 해당 시나리오 이벤트 1개 생성          │
+│    → 코스 3개 × 페이스 5개 = 15 페이스    │
+│    → 인기 페이스 재고 집중 배분            │
+│    → 판매 정보 생성                       │
+│ 4. 사전정보 저장 (preSaveRatio 지정 시)   │
+│ 5. Redis flushDB + 재고 초기화           │
+│ 6. 대기열 활성화 (WITH_QUEUE만)           │
+└─────────────────────────────────────────┘
+  ↓
+일괄 로그인 (http.batch)
+  ↓
+VU 실행 시작
+```
 
-### 1. k6 설치
+- **`local` 프로필에서만 활성화**되는 내부 API입니다.
+- SQL 파일 실행이나 Redis 수동 초기화가 **필요 없습니다**.
+
+### 2.2 2웨이브 구조 (시나리오 2, 3)
+
+선착순 시나리오는 **결제 이탈 → 재고 재순환**을 검증하는 2웨이브 구조입니다.
+
+```
+Wave 1 (VU 1 ~ VU_COUNT)
+  ├─ 선점 성공 → 70% 결제확정 / 30% 결제이탈 (TTL 15초 후 재고 반환)
+  └─ 매진 → 종료
+
+Wave 2 (VU VU_COUNT+1 ~ 총VU)
+  ├─ TTL 만료 대기 (18초)
+  └─ 이탈 재고 재선점 → 전원 결제확정
+```
+
+- Wave 2 인원은 `EXTRA_VU_COUNT` 또는 `VU_COUNT × PAYMENT_DROPOUT_RATIO`로 자동 계산
+- 총 VU = VU_COUNT + EXTRA_VU_COUNT
+
+### 2.3 페이스 배분
+
+```
+전체 VU의 70% (HOT_PACE_RATIO) → 인기 페이스 (라운드로빈)
+전체 VU의 30%                   → 나머지 페이스 (라운드로빈)
+```
+
+### 2.4 인기 페이스 재고 배분
+
+```
+총 재고 = totalStock (직접 지정 or VU_COUNT ÷ 경쟁률)
+
+인기 페이스 재고 = 총재고 × HOT_STOCK_RATIO ÷ HOT_PACE_COUNT
+나머지 재고      = (총재고 - 인기 총재고) ÷ (15 - HOT_PACE_COUNT)
+```
+
+---
+
+## 3. 사전 준비
+
+### 3.1 k6 설치
 
 ```bash
 # Windows
@@ -40,248 +113,415 @@ brew install k6
 k6 version
 ```
 
-### 2. Gateway 설정 변경
+### 3.2 Gateway 설정 변경
 
 `gateway/src/main/resources/application.yml`에서:
 
 1. **auth-route**: `RequestRateLimiter` 주석 처리 (IP 기반 rate limit 제거)
-2. **queue-route**: 주석 해제, BotDetectionFilter 주석 유지
-3. **entry-apply-first-come-route**: 주석 해제, BotDetectionFilter 주석 유지
+2. **queue-route**: 주석 해제, `BotDetectionFilter` 주석 유지
+3. **entry-apply-first-come-route**: 주석 해제, `BotDetectionFilter` 주석 유지
 
-### 3. 서비스 기동
-
-```bash
-# Docker로 전체 기동
-docker-compose up -d --build
-
-# 또는 개별 실행
-# Gateway(30000), Auth(31000), Main(32000), Queue(33000), MySQL, Redis
-```
-
-### 4. 데이터 셋업
-
-#### 방법 A: API 자동 셋업 (권장)
-
-k6 시나리오 스크립트(00~03)는 `setup()` 단계에서 아래 API를 자동 호출합니다.
-별도 SQL 실행이나 Redis 초기화가 **필요 없습니다**.
+### 3.3 서비스 기동
 
 ```bash
-# 수동으로 확인하려면:
-curl -X POST http://localhost:30000/main/internal/load-test/setup \
-  -H 'Content-Type: application/json' \
-  -d '{"stockPerPace": 100}'
+# Docker 전체 빌드 & 실행 (서비스 + 모니터링 스택)
+docker compose build --no-cache && docker compose up -d
+
+# 상태 확인
+docker compose ps
 ```
 
-이 API는 유저 3만명 등록(멱등) → 이전 데이터 정리 → 이벤트/코스/페이스/재고/판매정보 생성 → Redis flushDB + 재고 초기화 + 대기열 활성화를 한 번에 수행합니다.
-`local` 프로필에서만 활성화됩니다.
+> **Docker 빌드 시 `--no-cache` 필수**: 소스 코드 변경이 Gradle 캐시 레이어에 가려질 수 있습니다.
 
-#### 방법 B: SQL 수동 실행 (레거시)
+---
 
-API를 사용하지 않고 직접 SQL을 실행하는 경우:
+## 4. 실행 방법
+
+### 기본 실행
 
 ```bash
-# 유저 데이터 (30,000명)
-mysql -u root -p on-race-main < k6/data/setup-load-test-users.sql
-
-# 이벤트 데이터 (소규모: 100석/페이스)
-mysql -u root -p on-race-main < k6/data/setup-load-test-events.sql
-
-# 이벤트 데이터 (대규모: 667석/페이스) — 10K+ VU 테스트 시
-# mysql -u root -p on-race-main < k6/data/setup-load-test-events-large.sql
+k6 run backend/k6/scenarios/<시나리오파일>.js
 ```
 
-### 5. Redis 재고 초기화 (SQL 수동 실행 시만)
-
-API 셋업 사용 시 자동 처리됩니다. SQL 수동 실행 시에만 필요합니다.
+### 환경변수 지정
 
 ```bash
-curl -X POST http://localhost:30000/main/events/11/stock/init
-curl -X POST http://localhost:30000/main/events/12/stock/init
-curl -X POST http://localhost:30000/main/events/13/stock/init
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 backend/k6/scenarios/01-lottery.js
 ```
 
-### 6. 대기열 활성화 (SQL 수동 실행 + 시나리오 3만)
+### 실행 순서 권장
 
-API 셋업 사용 시 자동 처리됩니다.
-
-```bash
-curl -X POST http://localhost:30000/main/events/13/queue/enable
+```
+1. 00-smoke-test.js     ← 환경 검증 (5 VU)
+2. 01-lottery.js        ← 소규모 50~100 VU 검증
+3. 01-lottery.js        ← 목표 규모 (4,500 VU)
+4. 02-first-come-no-queue.js
+5. 03-first-come-with-queue.js
 ```
 
-## 실행
+> **시나리오 간 별도 초기화 불필요**: 각 시나리오의 setup()이 이전 데이터를 자동 정리합니다.
 
-### Phase 1: 스모크 테스트
+---
 
-```bash
-k6 run k6/scenarios/00-smoke-test.js
-```
+## 5. 환경변수 레퍼런스
 
-### Phase 2: 소규모 검증 (50~100 VU)
+모든 값은 `-e` 플래그로 오버라이드 가능합니다.
 
-```bash
-k6 run -e VU_COUNT=50 k6/scenarios/01-lottery.js
-# cleanup 후 →
-k6 run -e VU_COUNT=50 k6/scenarios/02-first-come-no-queue.js
-# cleanup 후 →
-k6 run -e VU_COUNT=50 k6/scenarios/03-first-come-with-queue.js
-```
-
-### Phase 3: 기획 목표 (4,500 VU, 1,500석)
-
-```bash
-k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 k6/scenarios/01-lottery.js
-k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 k6/scenarios/02-first-come-no-queue.js
-k6 run -e VU_COUNT=3800 -e RAMP_UP_SEC=60 -e HOLD_SEC=300 k6/scenarios/03-first-come-with-queue.js
-```
-
-### Phase 4: 대규모 (10,000~15,000 VU, 10,000석)
-
-```bash
-# 대규모 이벤트 데이터로 교체
-mysql -u root -p on-race-main < k6/data/setup-load-test-events-large.sql
-
-# .env에서 HIKARI 풀 50, 서비스 재시작 후
-k6 run -e VU_COUNT=10000 -e RAMP_UP_SEC=120 -e HOLD_SEC=300 k6/scenarios/02-first-come-no-queue.js
-```
-
-### Phase 5: 최대 스케일 (30,000 VU)
-
-```bash
-k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e LOGIN_TIMEOUT=180s \
-  k6/scenarios/02-first-come-no-queue.js
-```
-
-### Prometheus 연동
-
-```bash
-K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
-k6 run -o experimental-prometheus-rw -e VU_COUNT=4500 k6/scenarios/01-lottery.js
-```
-
-## 환경변수
+### 서버 설정
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
 | `BASE_URL` | `http://localhost:30000` | Gateway 주소 |
-| `VU_COUNT` | `100` | 동시 사용자 수 (최대 30,000) |
-| `USER_PASSWORD` | `Test1234!@` | 테스트 유저 비밀번호 |
-| `LOGIN_TIMEOUT` | `120s` | 로그인 HTTP 타임아웃 |
-| `HOT_PACE_RATIO` | `0.7` | HOT 페이스 집중 비율 |
+| `USER_PASSWORD` | `Test1234!@` | 테스트 유저 공통 비밀번호 |
+
+### VU & 부하 패턴
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `VU_COUNT` | `100` | Wave 1 동시 사용자 수 (최대 30,000) |
 | `RAMP_UP_SEC` | `10` | 램프업 시간(초) |
 | `HOLD_SEC` | `120` | 유지 시간(초) |
 | `RAMP_DOWN_SEC` | `5` | 램프다운 시간(초) |
+| `SETUP_TIMEOUT_SEC` | `600` | setup 단계 타임아웃(초) |
+
+### 재고 설정
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `TOTAL_STOCK` | *(자동)* | 이벤트당 총 재고. 미지정 시 `VU_COUNT ÷ COMPETITION_RATIO` |
+| `COMPETITION_RATIO` | `3` | 경쟁률 (3:1 → VU 4,500 시 재고 1,500) |
+| `HOT_PACE_COUNT` | `2` | 인기 페이스 수 (1~3) |
+| `HOT_STOCK_RATIO` | `0.4` | 인기 페이스에 배분할 재고 비율 (40%) |
+
+### 인기 페이스 고정 지정
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `HOT_COURSE_INDEX` | *(랜덤)* | 인기 코스 인덱스 (0=풀코스, 1=하프코스, 2=10km) |
+| `HOT_PACE_INDEX` | *(랜덤)* | 인기 페이스 인덱스 (0=3분, 1=4분, 2=5분, 3=6분, 4=7분) |
+
+> 두 값을 모두 지정하면 해당 코스-페이스 1개를 HOT으로 **고정**합니다.
+> 예: `-e HOT_COURSE_INDEX=2 -e HOT_PACE_INDEX=2` → 10km 코스 / 5분 페이스 고정
+
+### 사전정보 저장
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `PRE_SAVE_RATIO` | *(미지정=건너뜀)* | 사전정보 저장 비율. `0.7` = 70% 유저가 사전정보 저장 |
+
+### 결제 이탈 & 2웨이브 (시나리오 2, 3)
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `PAYMENT_DROPOUT_RATIO` | `0.3` | Wave 1 결제 이탈률 (30%) |
+| `EXTRA_VU_COUNT` | *(자동)* | Wave 2 추가 인원. 미지정 시 `VU_COUNT × PAYMENT_DROPOUT_RATIO` |
+| `RETRY_MAX_ROUNDS` | `5` | 매진 시 최대 재시도 횟수 |
+| `RETRY_WAIT_SEC` | `18` | 재시도 대기 시간 (TTL 15초 + 여유 3초) |
+
+### 대기열 설정 (시나리오 3)
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
 | `QUEUE_POLL_SEC` | `2` | 대기열 폴링 간격(초) |
 | `QUEUE_MAX_POLL` | `300` | 최대 폴링 횟수 |
-| `EVENT_LOTTERY` | `11` | 응모 이벤트 ID |
-| `EVENT_FC_NO_QUEUE` | `12` | 선착순(대기열X) 이벤트 ID |
-| `EVENT_FC_WITH_QUEUE` | `13` | 선착순(대기열O) 이벤트 ID |
-| `HOT_COURSE_ID` | (자동) | HOT 코스 ID (오버라이드) |
-| `HOT_PACE_ID` | (자동) | HOT 페이스 ID (오버라이드) |
-| `OTHER_PACES` | (자동) | 기타 페이스 JSON (오버라이드) |
 
-## ID 체계
+### 로그인 설정
 
-### API 셋업 사용 시 (권장)
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `LOGIN_TIMEOUT` | `120s` | 로그인 HTTP 타임아웃 |
+| `LOGIN_BATCH_SIZE` | `50` | 배치 로그인 단위 |
 
-`POST /main/internal/load-test/setup` API를 통해 데이터를 셋업하면 **auto_increment로 ID가 동적 할당**됩니다.
-k6 시나리오 스크립트(01~03)는 setup 응답의 `eventIds`와 `paceMap`을 사용하므로 고정 ID에 의존하지 않습니다.
+### 기타
 
-### SQL 수동 실행 시 (레거시)
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `HOT_PACE_RATIO` | `0.7` | VU의 70%가 인기 페이스 대상 |
 
-아래 고정 ID는 `k6/data/*.sql` 파일을 직접 실행할 때만 해당됩니다.
+---
 
-| 구분 | ID 범위 | 비고 |
-|------|---------|------|
-| 유저 | 10001~40000 | k6user00001~k6user30000 |
-| 이벤트 11 | 코스 31-33, 페이스 151-165 | 응모, HOT=162 |
-| 이벤트 12 | 코스 34-36, 페이스 166-180 | 선착순(대기열X), HOT=177 |
-| 이벤트 13 | 코스 37-39, 페이스 181-195 | 선착순(대기열O), HOT=192 |
+## 6. 시나리오별 실행 예시
 
-## 테스트 간 초기화
-
-시나리오 재실행 전 반드시:
+### 6.1 스모크 테스트
 
 ```bash
-# 1. SQL 초기화 (entry 삭제 + stock 리셋)
-mysql -u root -p on-race-main < k6/data/cleanup-between-tests.sql
-
-# 2. Redis 재고 초기화
-curl -X POST http://localhost:30000/main/events/11/stock/init
-curl -X POST http://localhost:30000/main/events/12/stock/init
-curl -X POST http://localhost:30000/main/events/13/stock/init
-
-# 3. 대기열 재활성화 (시나리오 3)
-curl -X POST http://localhost:30000/main/events/13/queue/enable
+k6 run backend/k6/scenarios/00-smoke-test.js
 ```
 
-## 기대 결과
+### 6.2 시나리오 1: 응모신청 (01-lottery)
 
-### 시나리오 1: 응모신청
+> 재고 제한 없음. 전원 신청 성공이 기대됩니다.
 
-| 항목 | 기대값 (4,500 VU) |
+```bash
+# 소규모 검증 (100명)
+k6 run -e VU_COUNT=100 backend/k6/scenarios/01-lottery.js
+
+# 기획 목표 (4,500명, 사전저장 70%)
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 -e PRE_SAVE_RATIO=0.7 \
+  backend/k6/scenarios/01-lottery.js
+
+# 대규모 (12,000명)
+k6 run -e VU_COUNT=12000 -e RAMP_UP_SEC=120 -e HOLD_SEC=300 -e PRE_SAVE_RATIO=0.7 \
+  backend/k6/scenarios/01-lottery.js
+
+# 최대 스케일 (30,000명)
+k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.7 \
+  -e LOGIN_TIMEOUT=180s backend/k6/scenarios/01-lottery.js
+```
+
+### 6.3 시나리오 2: 선착순 대기열X (02-first-come-no-queue)
+
+> 2웨이브 구조. 재고 소진 시 매진, 이탈 재고 재순환 검증.
+
+```bash
+# 소규모 검증 (100명)
+k6 run -e VU_COUNT=100 backend/k6/scenarios/02-first-come-no-queue.js
+
+# 기획 목표 (4,500명, 재고 1,500, 사전저장 70%)
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 -e PRE_SAVE_RATIO=0.7 \
+  backend/k6/scenarios/02-first-come-no-queue.js
+
+# 대규모 (12,000명, 재고 4,000)
+k6 run -e VU_COUNT=12000 -e RAMP_UP_SEC=120 -e HOLD_SEC=300 -e PRE_SAVE_RATIO=0.7 \
+  backend/k6/scenarios/02-first-come-no-queue.js
+
+# 최대 스케일 (30,000명, 재고 10,000)
+k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.7 \
+  -e LOGIN_TIMEOUT=180s backend/k6/scenarios/02-first-come-no-queue.js
+```
+
+### 6.4 시나리오 3: 선착순 대기열O (03-first-come-with-queue)
+
+> 2웨이브 구조 + 대기열 경유. PASS 수신 후 선착순 신청.
+
+```bash
+# 소규모 검증 (100명)
+k6 run -e VU_COUNT=100 backend/k6/scenarios/03-first-come-with-queue.js
+
+# 기획 목표 (4,500명, 재고 1,500, 사전저장 70%)
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 -e HOLD_SEC=300 -e PRE_SAVE_RATIO=0.7 \
+  backend/k6/scenarios/03-first-come-with-queue.js
+
+# 대규모 (12,000명, 재고 4,000)
+k6 run -e VU_COUNT=12000 -e RAMP_UP_SEC=120 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.7 \
+  backend/k6/scenarios/03-first-come-with-queue.js
+
+# 최대 스케일 (30,000명, 재고 10,000)
+k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.7 \
+  -e LOGIN_TIMEOUT=180s -e QUEUE_MAX_POLL=600 \
+  backend/k6/scenarios/03-first-come-with-queue.js
+```
+
+### 6.5 고급 옵션 조합 예시
+
+```bash
+# 인기 페이스 고정 (10km 코스 / 5분 페이스) + 재고 직접 지정
+k6 run -e VU_COUNT=4500 -e TOTAL_STOCK=2000 \
+  -e HOT_COURSE_INDEX=2 -e HOT_PACE_INDEX=2 -e HOT_PACE_COUNT=1 \
+  -e PRE_SAVE_RATIO=0.7 backend/k6/scenarios/01-lottery.js
+
+# 높은 경쟁률 (5:1) + 인기 페이스 3개
+k6 run -e VU_COUNT=4500 -e COMPETITION_RATIO=5 \
+  -e HOT_PACE_COUNT=3 -e HOT_STOCK_RATIO=0.6 \
+  backend/k6/scenarios/02-first-come-no-queue.js
+
+# 이탈률 50% + Wave 2 인원 직접 지정
+k6 run -e VU_COUNT=4500 -e PAYMENT_DROPOUT_RATIO=0.5 -e EXTRA_VU_COUNT=1000 \
+  backend/k6/scenarios/02-first-come-no-queue.js
+```
+
+---
+
+## 7. 모니터링 (Prometheus + Grafana)
+
+### Prometheus 연동 실행
+
+```bash
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
+k6 run -o experimental-prometheus-rw \
+  -e VU_COUNT=4500 -e RAMP_UP_SEC=60 \
+  backend/k6/scenarios/01-lottery.js
+```
+
+### Grafana 대시보드
+
+- Grafana: `http://localhost:3000` (admin / admin)
+- k6 기본 대시보드 import: Dashboard ID `18030`
+- Loki 로그 확인: Explore → Loki → `{container="main"}` 등
+
+---
+
+## 8. 결과 검증
+
+### 8.1 기대 결과
+
+#### 시나리오 1: 응모신청
+
+| 항목 | 기대값 (VU=4,500) |
 |------|-------------------|
-| 응모 성공 | VU_COUNT건 (전원 200) |
-| DB entry | VU_COUNT건 (status=APPLIED) |
+| 응모 성공 | 4,500건 (전원 200) |
+| DB entry | 4,500건 (status=APPLIED) |
 | p95 응답시간 | < 3초 |
 
-### 시나리오 2: 선착순 대기열X
+#### 시나리오 2: 선착순 대기열X
 
-| 항목 | 기대값 (4,500 VU / 1,500석) |
-|------|----------------------------|
-| 선점 성공 (200) | ~1,500건 |
-| 매진 응답 (400) | ~3,000건 |
-| 오버셀링 | **0건** |
+| 항목 | 기대값 (VU=4,500 / 재고=1,500) |
+|------|-------------------------------|
+| Wave 1 선점 성공 | ~1,500건 |
+| Wave 1 결제확정 | ~1,050건 (70%) |
+| Wave 1 결제이탈 | ~450건 (30%) |
+| Wave 2 재선점+확정 | ~450건 |
+| **오버셀링** | **0건** |
 | p95 응답시간 | < 3초 |
 
-### 시나리오 3: 선착순 대기열O
+#### 시나리오 3: 선착순 대기열O
 
-| 항목 | 기대값 (4,500 VU / 1,500석) |
-|------|----------------------------|
+| 항목 | 기대값 (VU=4,500 / 재고=1,500) |
+|------|-------------------------------|
 | PASS 수신 | 전원 |
-| 선점 성공 (200) | ~1,500건 |
-| 매진 응답 (400) | ~2,300건 |
-| 오버셀링 | **0건** |
+| Wave 1 선점 성공 | ~1,500건 |
+| Wave 1 결제확정 | ~1,050건 (70%) |
+| Wave 1 결제이탈 | ~450건 (30%) |
+| Wave 2 재선점+확정 | ~450건 |
+| **오버셀링** | **0건** |
 | queue_wait_time p95 | < 5분 |
 
-## 검증 쿼리
+### 8.2 검증 쿼리 (동적 ID)
+
+테스트 후 아래 쿼리로 결과를 검증합니다. Setup API가 동적 ID를 생성하므로, 먼저 이벤트 ID를 확인하세요.
 
 ```sql
--- 오버셀링 확인 (entry 수 <= stock 수)
+-- 최근 생성된 테스트 이벤트 확인
+SELECT id, title, type, is_queue_active
+FROM event
+WHERE title LIKE 'k6 부하테스트%'
+ORDER BY id DESC
+LIMIT 5;
+```
+
+```sql
+-- 오버셀링 확인 (entry 수 <= stock 수) — event_id를 위 결과로 교체
 SELECT ep.id AS pace_id, ep.name,
   es.total_stock,
   COUNT(e.id) AS entry_count,
   CASE WHEN COUNT(e.id) > es.total_stock THEN 'OVERSOLD!' ELSE 'OK' END AS status
 FROM event_pace ep
 JOIN event_stock es ON es.event_pace_id = ep.id
-LEFT JOIN entry e ON e.event_pace_id = ep.id AND e.status IN ('RESERVED', 'APPLIED')
-WHERE ep.id BETWEEN 151 AND 195
+LEFT JOIN entry e ON e.pace_id = ep.id AND e.status IN ('RESERVED', 'APPLIED')
+WHERE ep.event_course_id IN (
+  SELECT ec.id FROM event_course ec WHERE ec.event_id = <이벤트ID>
+)
 GROUP BY ep.id, ep.name, es.total_stock;
+```
 
--- 이벤트별 entry 집계
+```sql
+-- 이벤트별 entry 상태 집계
 SELECT e.event_id, COUNT(*) AS total,
   SUM(CASE WHEN e.status = 'APPLIED' THEN 1 ELSE 0 END) AS applied,
-  SUM(CASE WHEN e.status = 'RESERVED' THEN 1 ELSE 0 END) AS reserved
+  SUM(CASE WHEN e.status = 'RESERVED' THEN 1 ELSE 0 END) AS reserved,
+  SUM(CASE WHEN e.status = 'PRE_SAVED' THEN 1 ELSE 0 END) AS pre_saved
 FROM entry e
-WHERE e.user_id BETWEEN 10001 AND 40000
+WHERE e.event_id = <이벤트ID>
 GROUP BY e.event_id;
+```
 
--- 중복 entry 검증
+```sql
+-- 중복 entry 검증 (0건이어야 정상)
 SELECT user_id, event_id, COUNT(*) AS cnt
-FROM entry WHERE user_id BETWEEN 10001 AND 40000
+FROM entry
+WHERE event_id = <이벤트ID>
 GROUP BY user_id, event_id HAVING cnt > 1;
 ```
 
-## 커스텀 메트릭
+---
 
-| 시나리오 | 메트릭 | 타입 | 설명 |
-|---------|--------|------|------|
-| 01 | `lottery_apply_success` | Counter | 응모 성공 수 |
-| 01 | `lottery_apply_fail` | Counter | 응모 실패 수 |
-| 02 | `firstcome_reserve_success` | Counter | 선점 성공 수 |
-| 02 | `firstcome_sold_out` | Counter | 매진 응답 수 |
-| 02 | `firstcome_unexpected_error` | Counter | 예상 외 에러 수 |
-| 03 | `queue_wait_time` | Trend | 대기열 대기 시간(ms) |
-| 03 | `queue_pass_count` | Counter | PASS 수신 수 |
-| 03 | `queue_timeout_count` | Counter | 대기열 타임아웃 수 |
-| 03 | `queue_reserve_success` | Counter | 선점 성공 수 |
-| 03 | `queue_sold_out` | Counter | 매진 응답 수 |
+## 9. 커스텀 메트릭 레퍼런스
+
+### 시나리오 1: 응모신청
+
+| 메트릭 | 타입 | 설명 |
+|--------|------|------|
+| `lottery_apply_success` | Counter | 응모 성공 수 |
+| `lottery_apply_fail` | Counter | 응모 실패 수 |
+
+### 시나리오 2: 선착순 대기열X
+
+| 메트릭 | 타입 | 설명 |
+|--------|------|------|
+| `firstcome_reserve_success` | Counter | 선점 성공 수 |
+| `firstcome_payment_confirmed` | Counter | Wave 1 결제확정 수 |
+| `firstcome_payment_dropout` | Counter | Wave 1 결제이탈 수 |
+| `firstcome_wave2_confirmed` | Counter | Wave 2 재선점+확정 수 |
+| `firstcome_sold_out` | Counter | 최종 매진 수 |
+| `firstcome_already_reserved` | Counter | 중복 신청(409) 수 |
+| `firstcome_unexpected_error` | Counter | 예상 외 에러 수 |
+
+### 시나리오 3: 선착순 대기열O
+
+| 메트릭 | 타입 | 설명 |
+|--------|------|------|
+| `queue_wait_time` | Trend | 대기열 대기 시간(ms) |
+| `queue_pass_count` | Counter | PASS 수신 수 |
+| `queue_timeout_count` | Counter | 대기열 타임아웃 수 |
+| `queue_reserve_success` | Counter | 선점 성공 수 |
+| `queue_payment_confirmed` | Counter | Wave 1 결제확정 수 |
+| `queue_payment_dropout` | Counter | Wave 1 결제이탈 수 |
+| `queue_wave2_confirmed` | Counter | Wave 2 재선점+확정 수 |
+| `queue_sold_out` | Counter | 최종 매진 수 |
+| `queue_already_reserved` | Counter | 중복 신청(409) 수 |
+| `queue_unexpected_error` | Counter | 예상 외 에러 수 |
+
+---
+
+## 10. 트러블슈팅
+
+### Setup API 500 에러
+
+- **서버 미기동**: `docker compose ps`로 main 서비스 상태 확인. 기동 직후 3~5초 대기 필요.
+- **프로필 확인**: Setup API는 `@Profile("local")`에서만 활성화됩니다.
+- **로그 확인**: `docker compose logs main --tail=100`
+
+### 로그인 대량 실패
+
+- Gateway의 `RequestRateLimiter` 주석 처리 확인
+- `LOGIN_BATCH_SIZE` 줄이기 (기본 50)
+- `LOGIN_TIMEOUT` 늘리기 (기본 120s)
+
+### Docker 빌드 후 코드 변경 미반영
+
+```bash
+# 캐시 무시 재빌드
+docker compose build --no-cache && docker compose up -d
+```
+
+### 대규모 테스트 시 타임아웃
+
+- `SETUP_TIMEOUT_SEC` 늘리기 (기본 600초)
+- `RAMP_UP_SEC` 늘리기 (30,000 VU 시 180초 권장)
+- `HOLD_SEC` 늘리기 (대기열 시나리오는 충분한 시간 필요)
+
+### k6 setup 단계에서 메모리 부족
+
+- VU 30,000 기준 토큰 저장 메모리 약 150MB
+- k6 실행 머신의 여유 메모리 확인
+
+---
+
+## 프로젝트 구조
+
+```
+k6/
+├── scenarios/
+│   ├── 00-smoke-test.js              # 스모크 테스트 (5 VU)
+│   ├── 01-lottery.js                 # 응모신청
+│   ├── 02-first-come-no-queue.js     # 선착순 대기열X (2웨이브)
+│   └── 03-first-come-with-queue.js   # 선착순 대기열O (2웨이브)
+├── lib/
+│   ├── config.js        # 환경변수 & 기본값
+│   ├── setup.js         # Setup API 호출 (데이터 자동 셋업)
+│   ├── auth.js          # 로그인 & 토큰 관리 (배치 로그인)
+│   ├── distribution.js  # VU → 페이스 배분 (70/30 HOT 배분)
+│   ├── retry.js         # HTTP 재시도 래퍼
+│   └── log.js           # 로깅 유틸
+└── README.md            # 이 문서
+```

--- a/backend/k6/lib/auth.js
+++ b/backend/k6/lib/auth.js
@@ -1,0 +1,125 @@
+// ========================================================
+// 로그인 및 인증 헬퍼
+// Gateway 경유: POST /auth/login → Auth 서비스
+// ========================================================
+
+import http from 'k6/http';
+import { sleep } from 'k6';
+import { BASE_URL, USER_PASSWORD, LOGIN_TIMEOUT, LOGIN_BATCH_SIZE } from './config.js';
+
+/**
+ * VU 인덱스 → 이메일 (k6user00001@test.com ~ k6user30000@test.com)
+ */
+export function getUserEmail(vuIndex) {
+  return `k6user${String(vuIndex).padStart(5, '0')}@test.com`;
+}
+
+/**
+ * Gateway 경유 로그인, accessToken 반환
+ * 실패 시 null 반환
+ */
+export function login(vuIndex) {
+  const email = getUserEmail(vuIndex);
+  const res = http.post(
+    `${BASE_URL}/auth/login`,
+    JSON.stringify({ email: email, password: USER_PASSWORD }),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      tags: { name: 'login' },
+      timeout: LOGIN_TIMEOUT,
+    }
+  );
+
+  if (res.status !== 200) {
+    console.error(`Login failed [${email}]: ${res.status} ${res.body}`);
+    return null;
+  }
+
+  const body = res.json();
+  return body.data.accessToken;
+}
+
+/**
+ * 인증 헤더 생성
+ */
+export function authHeaders(token) {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  };
+}
+
+/**
+ * setup() 단계에서 전체 유저 일괄 로그인
+ * http.batch()를 사용하여 배치 단위로 병렬 로그인 수행
+ *
+ * @param {number} totalUsers - 총 유저 수 (VU 1 ~ totalUsers)
+ * @returns {Object} { "1": "token1", "2": "token2", ... }
+ */
+export function batchLoginAll(totalUsers) {
+  const tokens = {};
+  const batchSize = LOGIN_BATCH_SIZE;
+  const totalBatches = Math.ceil(totalUsers / batchSize);
+
+  console.log(`[setup] 일괄 로그인 시작: ${totalUsers}명, 배치=${batchSize}, 총 ${totalBatches}배치`);
+
+  for (let batchIdx = 0; batchIdx < totalBatches; batchIdx++) {
+    const start = batchIdx * batchSize + 1;
+    const end = Math.min((batchIdx + 1) * batchSize, totalUsers);
+
+    // http.batch() 요청 배열 구성
+    const requests = [];
+    for (let vuIdx = start; vuIdx <= end; vuIdx++) {
+      requests.push([
+        'POST',
+        `${BASE_URL}/auth/login`,
+        JSON.stringify({ email: getUserEmail(vuIdx), password: USER_PASSWORD }),
+        { headers: { 'Content-Type': 'application/json' }, tags: { name: 'setup_login' }, timeout: LOGIN_TIMEOUT },
+      ]);
+    }
+
+    // 배치 실행
+    const responses = http.batch(requests);
+
+    // 성공/실패 분류
+    const retryIndices = [];
+    for (let i = 0; i < responses.length; i++) {
+      const vuIdx = start + i;
+      if (responses[i].status === 200) {
+        try {
+          tokens[String(vuIdx)] = responses[i].json().data.accessToken;
+        } catch (e) {
+          retryIndices.push(i);
+        }
+      } else {
+        retryIndices.push(i);
+      }
+    }
+
+    // 실패분 1회 재시도
+    if (retryIndices.length > 0) {
+      console.warn(`[setup] 배치 ${batchIdx + 1}: ${retryIndices.length}건 실패, 2초 후 재시도`);
+      sleep(2);
+      const retryRequests = retryIndices.map((i) => requests[i]);
+      const retryResponses = http.batch(retryRequests);
+      for (let j = 0; j < retryResponses.length; j++) {
+        const vuIdx = start + retryIndices[j];
+        if (retryResponses[j].status === 200) {
+          try {
+            tokens[String(vuIdx)] = retryResponses[j].json().data.accessToken;
+          } catch (e) { /* skip */ }
+        } else {
+          console.error(`[setup] 재시도 실패 VU ${vuIdx}: ${retryResponses[j].status}`);
+        }
+      }
+    }
+
+    // 진행률 로깅 (10배치마다)
+    if ((batchIdx + 1) % 10 === 0 || batchIdx === totalBatches - 1) {
+      console.log(`[setup] 로그인 진행: ${batchIdx + 1}/${totalBatches} 배치 (${Object.keys(tokens).length}/${totalUsers} 성공)`);
+    }
+  }
+
+  console.log(`[setup] 일괄 로그인 완료: ${Object.keys(tokens).length}/${totalUsers} 성공`);
+  return tokens;
+}

--- a/backend/k6/lib/auth.js
+++ b/backend/k6/lib/auth.js
@@ -107,7 +107,9 @@ export function batchLoginAll(totalUsers) {
         if (retryResponses[j].status === 200) {
           try {
             tokens[String(vuIdx)] = retryResponses[j].json().data.accessToken;
-          } catch (e) { /* skip */ }
+          } catch (e) {
+            console.warn(`[setup] VU ${vuIdx} 토큰 파싱 실패: ${e.message}`);
+          }
         } else {
           console.error(`[setup] 재시도 실패 VU ${vuIdx}: ${retryResponses[j].status}`);
         }

--- a/backend/k6/lib/config.js
+++ b/backend/k6/lib/config.js
@@ -1,0 +1,60 @@
+// ========================================================
+// k6 부하테스트 공통 설정
+// 모든 값은 환경변수(-e)로 오버라이드 가능
+// ========================================================
+
+// === 서버 설정 ===
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:30000';
+
+// === 시나리오별 이벤트 ID (setup-load-test-events.sql 기준) ===
+export const EVENT_IDS = {
+  LOTTERY:                parseInt(__ENV.EVENT_LOTTERY || '11'),
+  FIRST_COME_NO_QUEUE:   parseInt(__ENV.EVENT_FC_NO_QUEUE || '12'),
+  FIRST_COME_WITH_QUEUE: parseInt(__ENV.EVENT_FC_WITH_QUEUE || '13'),
+};
+
+// === 유저 설정 (최대 30,000명) ===
+export const VU_COUNT      = parseInt(__ENV.VU_COUNT || '100');
+export const USER_PASSWORD = __ENV.USER_PASSWORD || 'Test1234!@';
+
+// === 로그인 설정 ===
+export const LOGIN_TIMEOUT    = __ENV.LOGIN_TIMEOUT || '120s';
+export const LOGIN_BATCH_SIZE = parseInt(__ENV.LOGIN_BATCH_SIZE || '50');
+
+// === 페이스 배분 (70% HOT, 30% 기타) ===
+export const HOT_PACE_RATIO = parseFloat(__ENV.HOT_PACE_RATIO || '0.7');
+
+// === Setup 타임아웃 (데이터 셋업 + 로그인) ===
+export const SETUP_TIMEOUT_SEC = parseInt(__ENV.SETUP_TIMEOUT_SEC || '600');
+
+// === 부하 패턴 (ramping-vus) ===
+export const RAMP_UP_SEC   = parseInt(__ENV.RAMP_UP_SEC || '10');
+export const HOLD_SEC      = parseInt(__ENV.HOLD_SEC || '120');
+export const RAMP_DOWN_SEC = parseInt(__ENV.RAMP_DOWN_SEC || '5');
+
+// === 재고 설정 ===
+export const TOTAL_STOCK       = __ENV.TOTAL_STOCK ? parseInt(__ENV.TOTAL_STOCK) : null;  // 직접 지정 (null이면 자동 계산)
+export const COMPETITION_RATIO = parseInt(__ENV.COMPETITION_RATIO || '3');     // 경쟁률 (3:1) — TOTAL_STOCK 미지정 시 사용
+export const HOT_PACE_COUNT    = parseInt(__ENV.HOT_PACE_COUNT || '2');        // 인기 페이스 수 (랜덤 선정)
+export const HOT_STOCK_RATIO   = parseFloat(__ENV.HOT_STOCK_RATIO || '0.4');  // 인기 페이스 재고 비율 (40%)
+
+// === 인기 페이스 고정 지정 (두 값 모두 지정 시 해당 코스-페이스 1개를 hot으로 고정) ===
+export const HOT_COURSE_INDEX = __ENV.HOT_COURSE_INDEX != null ? parseInt(__ENV.HOT_COURSE_INDEX) : null;  // 0=풀코스, 1=하프��스, 2=10km
+export const HOT_PACE_INDEX   = __ENV.HOT_PACE_INDEX != null ? parseInt(__ENV.HOT_PACE_INDEX) : null;      // 0=3분, 1=4분, 2=5분, 3=6분, 4=7분
+
+// === 사전정보 저장 비율 ===
+export const PRE_SAVE_RATIO = __ENV.PRE_SAVE_RATIO != null ? parseFloat(__ENV.PRE_SAVE_RATIO) : null;  // null이면 건너뜀, 0.7이면 70%
+
+// === Queue 폴링 설정 ===
+export const QUEUE_POLL_INTERVAL_SEC = parseInt(__ENV.QUEUE_POLL_SEC || '2');
+export const QUEUE_MAX_POLL_COUNT    = parseInt(__ENV.QUEUE_MAX_POLL || '300');
+
+// === 결제 이탈 + 2웨이브 설정 ===
+export const PAYMENT_DROPOUT_RATIO = parseFloat(__ENV.PAYMENT_DROPOUT_RATIO || '0.3');  // 30% 이탈
+export const RETRY_MAX_ROUNDS      = parseInt(__ENV.RETRY_MAX_ROUNDS || '5');            // 매진 시 최대 재시도 횟수
+export const RETRY_WAIT_SEC        = parseInt(__ENV.RETRY_WAIT_SEC || '18');             // 재시도 대기 (TTL 15초 + 여유 3초)
+
+// === Wave 2 추가 인원 (이탈자 재고 재선점) ===
+export const EXTRA_VU_COUNT = __ENV.EXTRA_VU_COUNT != null
+  ? parseInt(__ENV.EXTRA_VU_COUNT)
+  : Math.ceil(VU_COUNT * PAYMENT_DROPOUT_RATIO);  // 미지정 시 이탈률 기반 자동 계산

--- a/backend/k6/lib/distribution.js
+++ b/backend/k6/lib/distribution.js
@@ -1,0 +1,41 @@
+// ========================================================
+// 유저 → 페이스 배분 로직
+// 70% HOT 페이스 집중, 30% 나머지 페이스 분산
+//
+// setup API 응답의 paceMap을 사용하여 동적 배분
+// paceMap[eventId] = { hot: [{ courseId, paceId, stock }], others: [...] }
+// ========================================================
+
+import { HOT_PACE_RATIO, VU_COUNT } from './config.js';
+
+/**
+ * VU를 페이스에 배분 (동적 paceMap 기반)
+ * @param {number} vuIndex - VU 번호 (1-based, __VU)
+ * @param {Object} paceMapEntry - { hot: [{ courseId, paceId }], others: [{ courseId, paceId }, ...] }
+ * @returns {{ courseId: number, paceId: number }}
+ */
+export function assignPace(vuIndex, paceMapEntry) {
+  if (!paceMapEntry || !paceMapEntry.hot || paceMapEntry.hot.length === 0) {
+    console.error(`VU ${vuIndex}: paceMapEntry가 없습니다`);
+    return { courseId: 0, paceId: 0 };
+  }
+
+  const hotCutoff = Math.floor(VU_COUNT * HOT_PACE_RATIO);
+
+  // 70%: HOT 페이스 (여러 개일 경우 라운드로빈)
+  if (vuIndex <= hotCutoff) {
+    const hotPaces = paceMapEntry.hot;
+    const idx = (vuIndex - 1) % hotPaces.length;
+    return { courseId: hotPaces[idx].courseId, paceId: hotPaces[idx].paceId };
+  }
+
+  // 30%: 나머지 페이스 라운드로빈
+  const others = paceMapEntry.others;
+  if (!others || others.length === 0) {
+    const fallback = paceMapEntry.hot[0];
+    return { courseId: fallback.courseId, paceId: fallback.paceId };
+  }
+
+  const idx = (vuIndex - hotCutoff - 1) % others.length;
+  return { courseId: others[idx].courseId, paceId: others[idx].paceId };
+}

--- a/backend/k6/lib/log.js
+++ b/backend/k6/lib/log.js
@@ -1,0 +1,22 @@
+// ========================================================
+// k6 부하테스트 로거 (대규모 테스트 최적화)
+//
+// - errorLog: 모든 VU — 에러/예외 상황만
+// - resultLog: VU 1만 — 정상 흐름 검증용
+// ========================================================
+
+/**
+ * 에러 로그 (모든 VU 출력)
+ */
+export function errorLog(vu, msg) {
+  console.error(`[VU ${vu}] ERROR: ${msg}`);
+}
+
+/**
+ * 결과 로그 (VU 1만 출력 — 흐름 검증용)
+ */
+export function resultLog(vu, result, retries) {
+  if (vu !== 1) return;
+  const retryInfo = retries > 0 ? ` (재시도 ${retries}회)` : '';
+  console.log(`[VU 1] ${result}${retryInfo}`);
+}

--- a/backend/k6/lib/retry.js
+++ b/backend/k6/lib/retry.js
@@ -1,0 +1,53 @@
+// ========================================================
+// HTTP 요청 재시도 헬퍼
+// 5xx 서버 에러 시 지수 백오프로 재시도
+// ========================================================
+
+import { sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+
+export const retryCount   = new Counter('retry_count');
+export const retrySuccess = new Counter('retry_success');
+
+/**
+ * HTTP 요청 함수를 재시도하는 래퍼
+ *
+ * @param {Function} requestFn - () => http.Response 반환 함수
+ * @param {Object} [opts]
+ * @param {number} [opts.maxRetries=3]  - 최대 재시도 횟수
+ * @param {number} [opts.backoffSec=2]  - 초기 백오프(초)
+ * @param {string} [opts.name='request'] - 로그용 이름
+ * @param {number} [opts.vu=0]          - VU 번호 (로그용)
+ * @returns {{ res: Object, retries: number }}
+ */
+export function withRetry(requestFn, opts = {}) {
+  const maxRetries = opts.maxRetries != null ? opts.maxRetries : 3;
+  const backoffSec = opts.backoffSec != null ? opts.backoffSec : 2;
+  const name = opts.name || 'request';
+  const vu = opts.vu || 0;
+
+  let res = requestFn();
+  let retries = 0;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // 5xx만 재시도, 4xx(비즈니스 에러)는 즉시 반환
+    if (res.status < 500) {
+      break;
+    }
+
+    retryCount.add(1);
+    retries = attempt;
+
+    const delaySec = backoffSec * Math.pow(2, attempt - 1) * (0.5 + Math.random() * 0.5);
+    console.warn(`[VU ${vu}] ${name} 재시도 (${attempt}/${maxRetries}) — ${res.status}, ${delaySec.toFixed(1)}초 후 재시도`);
+
+    sleep(delaySec);
+    res = requestFn();
+  }
+
+  if (retries > 0 && res.status < 500) {
+    retrySuccess.add(1);
+  }
+
+  return { res, retries };
+}

--- a/backend/k6/lib/setup.js
+++ b/backend/k6/lib/setup.js
@@ -1,0 +1,71 @@
+// ========================================================
+// 부하테스트 데이터 자동 셋업 헬퍼
+// setup()에서 호출하여 DB/Redis 자동 초기화
+//
+// 반환값:
+//   eventIds  — { LOTTERY: N } | { FIRST_COME_NO_QUEUE: N } | ... (scenarioType에 따라 1개 또는 전체)
+//   paceMap   — { "N": { hot: [{ courseId, paceId, stock }], others: [...] }, ... }
+// ========================================================
+
+import http from 'k6/http';
+import { check } from 'k6';
+import {
+  BASE_URL, VU_COUNT, TOTAL_STOCK,
+  COMPETITION_RATIO, HOT_PACE_COUNT, HOT_STOCK_RATIO,
+  HOT_COURSE_INDEX, HOT_PACE_INDEX, PRE_SAVE_RATIO,
+} from './config.js';
+
+/**
+ * 부하테스트 데이터 자동 셋업
+ * @param {string|null} scenarioType — 'LOTTERY' | 'FIRST_COME_NO_QUEUE' | 'FIRST_COME_WITH_QUEUE' | null(전체)
+ * @returns {{ eventIds: Object, paceMap: Object }}
+ */
+export function setupTestData(scenarioType = null) {
+  const estimatedStock = TOTAL_STOCK || Math.ceil(VU_COUNT / COMPETITION_RATIO);
+  console.log(`[setup] 테스트 데이터 셋업 시작 (scenario=${scenarioType || 'ALL'}, totalUsers=${VU_COUNT}, totalStock=${TOTAL_STOCK ? TOTAL_STOCK + '(직접지정)' : estimatedStock + '(자동계산)'}, hotPaces=${HOT_PACE_COUNT}, hotRatio=${HOT_STOCK_RATIO})`);
+
+  const body = {
+    totalUsers: VU_COUNT,
+    competitionRatio: COMPETITION_RATIO,
+    hotPaceCount: HOT_PACE_COUNT,
+    hotStockRatio: HOT_STOCK_RATIO,
+  };
+  if (scenarioType) body.scenarioType = scenarioType;
+  if (TOTAL_STOCK) body.totalStock = TOTAL_STOCK;
+  if (HOT_COURSE_INDEX != null) body.hotCourseIndex = HOT_COURSE_INDEX;
+  if (HOT_PACE_INDEX != null) body.hotPaceIndex = HOT_PACE_INDEX;
+  if (PRE_SAVE_RATIO != null) body.preSaveRatio = PRE_SAVE_RATIO;
+
+  const res = http.post(
+    `${BASE_URL}/main/internal/load-test/setup`,
+    JSON.stringify(body),
+    {
+      headers: { 'Content-Type': 'application/json' },
+      tags: { name: 'setup_test_data' },
+      timeout: '300s',
+    }
+  );
+
+  const ok = check(res, {
+    '테스트 데이터 셋업 성공': (r) => r.status === 200,
+  });
+
+  if (!ok) {
+    console.error(`[setup] 테스트 데이터 셋업 실패: ${res.status} ${res.body}`);
+    throw new Error('테스트 데이터 셋업 실패 — 서버 상태를 확인하세요');
+  }
+
+  const data = res.json().data;
+  console.log(`[setup] 셋업 완료 — users=${data.userCount} (skipped=${data.userSkipped}), events=${JSON.stringify(data.eventIds)}, totalStock=${data.totalStock}, preSave=${data.preSaveCount || 0}`);
+
+  // 인기 페이스 정보 로그
+  for (const [eventId, entry] of Object.entries(data.paceMap)) {
+    const hotInfo = entry.hot.map((p) => `paceId=${p.paceId}(${p.stock}석)`).join(', ');
+    console.log(`[setup] 이벤트 ${eventId} 인기 페이스: ${hotInfo}`);
+  }
+
+  return {
+    eventIds: data.eventIds,
+    paceMap: data.paceMap,
+  };
+}

--- a/backend/k6/scenarios/00-smoke-test.js
+++ b/backend/k6/scenarios/00-smoke-test.js
@@ -1,0 +1,75 @@
+// ========================================================
+// 스모크 테스트: 환경 검증 (5 VU)
+//
+// 목적: 본 테스트 전 서비스 정상 동작 확인
+// 흐름: 데이터 셋업 → 로그인 → 이벤트 조회 (3개) → 재고 확인
+// 실행: k6 run k6/scenarios/00-smoke-test.js
+// ========================================================
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { batchLoginAll, authHeaders } from '../lib/auth.js';
+import { setupTestData } from '../lib/setup.js';
+import { BASE_URL } from '../lib/config.js';
+
+const SMOKE_VU = 5;
+
+export const options = {
+  vus: SMOKE_VU,
+  iterations: SMOKE_VU,
+  setupTimeout: '300s',
+  thresholds: {
+    http_req_failed: ['rate==0'],
+  },
+};
+
+// ── setup: 데이터 셋업 → 5명 로그인 ──
+export function setup() {
+  const testData = setupTestData();
+  const tokens = batchLoginAll(SMOKE_VU);
+  return { tokens, eventIds: testData.eventIds, paceMap: testData.paceMap };
+}
+
+export default function (data) {
+  // 1. 사전 로그인 토큰 획득
+  const token = data.tokens[String(__VU)];
+  const loginOk = check(token, {
+    '로그인 성공': (t) => t != null,
+  });
+  if (!loginOk) return;
+
+  const headers = authHeaders(token);
+
+  // 2. 각 이벤트 조회 (동적 ID)
+  const eventIds = [
+    data.eventIds.LOTTERY,
+    data.eventIds.FIRST_COME_NO_QUEUE,
+    data.eventIds.FIRST_COME_WITH_QUEUE,
+  ];
+  for (const eid of eventIds) {
+    const res = http.get(`${BASE_URL}/main/events/${eid}`, {
+      headers: headers,
+      tags: { name: 'event_detail' },
+    });
+    check(res, {
+      [`이벤트 ${eid} 조회 성공`]: (r) => r.status === 200,
+    });
+  }
+
+  // 3. 재고 확인 (paceMap에서 HOT paceId 동적 추출)
+  const fcNoQueueId = data.eventIds.FIRST_COME_NO_QUEUE;
+  const paceMapEntry = data.paceMap[String(fcNoQueueId)];
+  const hotPaceId = paceMapEntry && paceMapEntry.hot ? paceMapEntry.hot.paceId : null;
+
+  if (hotPaceId) {
+    const stockRes = http.get(
+      `${BASE_URL}/main/events/${fcNoQueueId}/entries/stock-check?paceId=${hotPaceId}`,
+      { headers: headers, tags: { name: 'stock_check' } }
+    );
+    check(stockRes, {
+      '재고 조회 성공': (r) => r.status === 200,
+    });
+  }
+
+  sleep(1);
+}

--- a/backend/k6/scenarios/00-smoke-test.js
+++ b/backend/k6/scenarios/00-smoke-test.js
@@ -59,7 +59,9 @@ export default function (data) {
   // 3. 재고 확인 (paceMap에서 HOT paceId 동적 추출)
   const fcNoQueueId = data.eventIds.FIRST_COME_NO_QUEUE;
   const paceMapEntry = data.paceMap[String(fcNoQueueId)];
-  const hotPaceId = paceMapEntry && paceMapEntry.hot ? paceMapEntry.hot.paceId : null;
+  const hotPaceId = paceMapEntry && paceMapEntry.hot && paceMapEntry.hot.length > 0
+    ? paceMapEntry.hot[0].paceId
+    : null;
 
   if (hotPaceId) {
     const stockRes = http.get(

--- a/backend/k6/scenarios/01-lottery.js
+++ b/backend/k6/scenarios/01-lottery.js
@@ -1,0 +1,116 @@
+// ========================================================
+// 시나리오 1: 응모신청 부하 테스트
+//
+// 흐름: [setup] 데이터 셋업 → 일괄 로그인 → [VU] 응모신청 (1회)
+// 재시도: 5xx 에러 시 1회 재시도
+// 기대: 전원 신청 성공 (재고 제한 없음)
+// 실행: k6 run -e VU_COUNT=100 k6/scenarios/01-lottery.js
+// ========================================================
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+import { batchLoginAll, authHeaders } from '../lib/auth.js';
+import { setupTestData } from '../lib/setup.js';
+import { assignPace } from '../lib/distribution.js';
+import { withRetry } from '../lib/retry.js';
+import { errorLog, resultLog } from '../lib/log.js';
+import {
+  BASE_URL, VU_COUNT,
+  RAMP_UP_SEC, HOLD_SEC, RAMP_DOWN_SEC,
+  SETUP_TIMEOUT_SEC,
+} from '../lib/config.js';
+
+// 커스텀 메트릭
+const applySuccess = new Counter('lottery_apply_success');
+const applyFail    = new Counter('lottery_apply_fail');
+
+export const options = {
+  setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
+  scenarios: {
+    lottery: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: `${RAMP_UP_SEC}s`, target: VU_COUNT },
+        { duration: `${HOLD_SEC}s`, target: VU_COUNT },
+        { duration: `${RAMP_DOWN_SEC}s`, target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:lottery_apply}': ['p(95)<3000'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+// ── setup: 데이터 셋업 → 일괄 사전 로그인 ──
+export function setup() {
+  const testData = setupTestData('LOTTERY');
+  const tokens = batchLoginAll(VU_COUNT);
+  return { tokens, eventIds: testData.eventIds, paceMap: testData.paceMap };
+}
+
+export default function (data) {
+  if (__ITER > 0) {
+    sleep(HOLD_SEC);
+    return;
+  }
+
+  const token = data.tokens[String(__VU)];
+  if (!token) {
+    errorLog(__VU, '토큰 미획득, 건너뜀');
+    return;
+  }
+
+  const eventId = data.eventIds.LOTTERY;
+  const { courseId, paceId } = assignPace(__VU, data.paceMap[String(eventId)]);
+  const headers = authHeaders(token);
+
+  // 재고 조회
+  const stockRes = http.get(
+    `${BASE_URL}/main/events/${eventId}/entries/stock-check?paceId=${paceId}`,
+    { headers, tags: { name: 'stock_check' } }
+  );
+  check(stockRes, {
+    'stock-check 200': (r) => r.status === 200,
+  });
+
+  // 토큰 검증 (네거티브 테스트)
+  const noAuthRes = http.post(
+    `${BASE_URL}/main/events/${eventId}/entries/apply/lottery`,
+    JSON.stringify({ courseId, paceId }),
+    {
+      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer invalid-token' },
+      tags: { name: 'neg_no_auth' },
+      responseCallback: http.expectedStatuses(401),
+    }
+  );
+  check(noAuthRes, { 'invalid JWT → 401': (r) => r.status === 401 });
+
+  // 응모 신청
+  const { res, retries } = withRetry(
+    () => http.post(
+      `${BASE_URL}/main/events/${eventId}/entries/apply/lottery`,
+      JSON.stringify({ courseId, paceId }),
+      { headers, tags: { name: 'lottery_apply' } }
+    ),
+    { maxRetries: 1, backoffSec: 2, name: '응모 신청', vu: __VU }
+  );
+
+  const ok = check(res, {
+    'lottery 200': (r) => r.status === 200,
+    'has entryId': (r) => {
+      try { return r.json().data.entryId != null; }
+      catch (e) { return false; }
+    },
+  });
+
+  if (ok) {
+    applySuccess.add(1);
+    resultLog(__VU, `응모 성공`, retries);
+  } else {
+    applyFail.add(1);
+    errorLog(__VU, `응모 실패 (${res.status})`);
+  }
+}

--- a/backend/k6/scenarios/02-first-come-no-queue.js
+++ b/backend/k6/scenarios/02-first-come-no-queue.js
@@ -1,0 +1,180 @@
+// ========================================================
+// 시나리오 2: 선착순 대기열X 부하 테스트 (2웨이브)
+//
+// Wave 1: VU 1~VU_COUNT — 신청 → 이탈/결제확정
+// Wave 2: VU VU_COUNT+1~총VU — TTL 만료 대기 → 이탈 재고 재선점 → 전원 결제확정
+//
+// 핵심: 오버셀링 0건 + 이탈자 재고 재순환 검증
+// 실행: k6 run -e VU_COUNT=100 k6/scenarios/02-first-come-no-queue.js
+// ========================================================
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter } from 'k6/metrics';
+import { batchLoginAll, authHeaders } from '../lib/auth.js';
+import { setupTestData } from '../lib/setup.js';
+import { assignPace } from '../lib/distribution.js';
+import { withRetry } from '../lib/retry.js';
+import { errorLog, resultLog } from '../lib/log.js';
+import {
+  BASE_URL, VU_COUNT, EXTRA_VU_COUNT,
+  RAMP_UP_SEC, HOLD_SEC, RAMP_DOWN_SEC,
+  SETUP_TIMEOUT_SEC,
+  PAYMENT_DROPOUT_RATIO, RETRY_MAX_ROUNDS, RETRY_WAIT_SEC,
+} from '../lib/config.js';
+
+const TOTAL_VUS = VU_COUNT + EXTRA_VU_COUNT;
+
+// 커스텀 메트릭
+const reserveSuccess   = new Counter('firstcome_reserve_success');
+const paymentConfirmed = new Counter('firstcome_payment_confirmed');
+const paymentDropout   = new Counter('firstcome_payment_dropout');
+const wave2Confirmed   = new Counter('firstcome_wave2_confirmed');
+const soldOut          = new Counter('firstcome_sold_out');
+const alreadyReserved  = new Counter('firstcome_already_reserved');
+const unexpectedErr    = new Counter('firstcome_unexpected_error');
+
+export const options = {
+  setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
+  scenarios: {
+    firstcome: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: `${RAMP_UP_SEC}s`, target: TOTAL_VUS },
+        { duration: `${HOLD_SEC}s`, target: TOTAL_VUS },
+        { duration: `${RAMP_DOWN_SEC}s`, target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:firstcome_apply}': ['p(95)<3000'],
+  },
+};
+
+export function setup() {
+  const testData = setupTestData('FIRST_COME_NO_QUEUE');
+  const tokens = batchLoginAll(TOTAL_VUS);
+  console.log(`[setup] 2웨이브 구성 — Wave1: ${VU_COUNT}명, Wave2: ${EXTRA_VU_COUNT}명, 총 ${TOTAL_VUS}명`);
+  return { tokens, eventIds: testData.eventIds, paceMap: testData.paceMap };
+}
+
+export default function (data) {
+  if (__ITER > 0) {
+    sleep(HOLD_SEC);
+    return;
+  }
+
+  const token = data.tokens[String(__VU)];
+  if (!token) {
+    errorLog(__VU, '토큰 미획득, 건너뜀');
+    return;
+  }
+
+  const isWave2 = __VU > VU_COUNT;
+  const eventId = data.eventIds.FIRST_COME_NO_QUEUE;
+  const { courseId, paceId } = assignPace(__VU, data.paceMap[String(eventId)]);
+  const headers = authHeaders(token);
+
+  // Wave 2: TTL 만료 대기 후 시작
+  if (isWave2) {
+    sleep(RETRY_WAIT_SEC);
+  }
+
+  // 재고 조회
+  const stockRes = http.get(
+    `${BASE_URL}/main/events/${eventId}/entries/stock-check?paceId=${paceId}`,
+    { headers, tags: { name: 'stock_check' } }
+  );
+  check(stockRes, {
+    'stock-check 200': (r) => r.status === 200,
+  });
+
+  // 토큰 검증 (Wave 1만 — Wave 2는 스킵하여 시간 절약)
+  if (!isWave2) {
+    const noAuthRes = http.post(
+      `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
+      JSON.stringify({ courseId, paceId }),
+      {
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer invalid-token' },
+        tags: { name: 'neg_no_auth' },
+        responseCallback: http.expectedStatuses(401),
+      }
+    );
+    check(noAuthRes, { 'invalid JWT → 401': (r) => r.status === 401 });
+  }
+
+  // ── 선착순 신청 + 결제 루프 ──
+  let totalRetries = 0;
+
+  for (let round = 0; round <= RETRY_MAX_ROUNDS; round++) {
+    if (round > 0) sleep(RETRY_WAIT_SEC);
+
+    const { res, retries } = withRetry(
+      () => http.post(
+        `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
+        JSON.stringify({ courseId, paceId }),
+        {
+          headers,
+          tags: { name: 'firstcome_apply' },
+          responseCallback: http.expectedStatuses(200, 400, 409),
+        }
+      ),
+      { maxRetries: 1, backoffSec: 2, name: '선착순 신청', vu: __VU }
+    );
+    totalRetries += retries;
+
+    if (res.status === 200) {
+      reserveSuccess.add(1);
+
+      // Wave 1: 이탈/확정 판단 / Wave 2: 전원 결제확정
+      if (!isWave2 && Math.random() < PAYMENT_DROPOUT_RATIO) {
+        paymentDropout.add(1);
+        resultLog(__VU, `결제 이탈 (라운드 ${round})`, totalRetries);
+        break;
+      }
+
+      const confirmRes = http.post(
+        `${BASE_URL}/main/internal/load-test/confirm-reservation`,
+        JSON.stringify({ paceId }),
+        { headers, tags: { name: 'confirm_reservation' } }
+      );
+
+      if (confirmRes.status === 200) {
+        if (isWave2) {
+          wave2Confirmed.add(1);
+          resultLog(__VU, `Wave2 결제 확정 (라운드 ${round})`, totalRetries);
+        } else {
+          paymentConfirmed.add(1);
+          resultLog(__VU, `결제 확정 (라운드 ${round})`, totalRetries);
+        }
+      } else {
+        unexpectedErr.add(1);
+        errorLog(__VU, `결제 확정 실패 (${confirmRes.status}, 라운드 ${round})`);
+      }
+      break;
+
+    } else if (res.status === 409) {
+      try {
+        const code = res.json().code;
+        if (code === 'ENT_010') {
+          alreadyReserved.add(1);
+        }
+        if (round === RETRY_MAX_ROUNDS) {
+          soldOut.add(1);
+          resultLog(__VU, `최종 매진 (${code})`, totalRetries);
+        }
+      } catch (e) {
+        if (round === RETRY_MAX_ROUNDS) {
+          soldOut.add(1);
+          resultLog(__VU, '최종 매진 (409)', totalRetries);
+        }
+      }
+
+    } else {
+      unexpectedErr.add(1);
+      errorLog(__VU, `예상 외 에러 (${res.status}, 라운드 ${round})`);
+      break;
+    }
+  }
+}

--- a/backend/k6/scenarios/03-first-come-with-queue.js
+++ b/backend/k6/scenarios/03-first-come-with-queue.js
@@ -1,0 +1,261 @@
+// ========================================================
+// 시나리오 3: 선착순 대기열O 부하 테스트 (2웨이브)
+//
+// Wave 1: VU 1~VU_COUNT — 대기열 → 신청 → 이탈/결제확정
+// Wave 2: VU VU_COUNT+1~총VU — TTL 만료 대기 → 대기열 → 이탈 재고 재선점 → 전원 결제확정
+//
+// 핵심: 오버셀링 0건 + 이탈자 재고 재순환 검증 (대기열 경유)
+// 실행: k6 run -e VU_COUNT=100 k6/scenarios/03-first-come-with-queue.js
+// ========================================================
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { batchLoginAll, authHeaders } from '../lib/auth.js';
+import { setupTestData } from '../lib/setup.js';
+import { assignPace } from '../lib/distribution.js';
+import { withRetry } from '../lib/retry.js';
+import { errorLog, resultLog } from '../lib/log.js';
+import {
+  BASE_URL, VU_COUNT, EXTRA_VU_COUNT,
+  RAMP_UP_SEC, HOLD_SEC, RAMP_DOWN_SEC,
+  SETUP_TIMEOUT_SEC,
+  QUEUE_POLL_INTERVAL_SEC, QUEUE_MAX_POLL_COUNT,
+  PAYMENT_DROPOUT_RATIO, RETRY_MAX_ROUNDS, RETRY_WAIT_SEC,
+} from '../lib/config.js';
+
+const TOTAL_VUS = VU_COUNT + EXTRA_VU_COUNT;
+
+// 커스텀 메트릭
+const queueWaitTime     = new Trend('queue_wait_time');
+const queuePassCount    = new Counter('queue_pass_count');
+const queueTimeoutCount = new Counter('queue_timeout_count');
+const reserveSuccess    = new Counter('queue_reserve_success');
+const paymentConfirmed  = new Counter('queue_payment_confirmed');
+const paymentDropout    = new Counter('queue_payment_dropout');
+const wave2Confirmed    = new Counter('queue_wave2_confirmed');
+const soldOut           = new Counter('queue_sold_out');
+const alreadyReserved   = new Counter('queue_already_reserved');
+const unexpectedErr     = new Counter('queue_unexpected_error');
+
+export const options = {
+  setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
+  scenarios: {
+    queue: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: `${RAMP_UP_SEC}s`, target: TOTAL_VUS },
+        { duration: `${HOLD_SEC}s`, target: TOTAL_VUS },
+        { duration: `${RAMP_DOWN_SEC}s`, target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    'http_req_duration{name:queue_enter}': ['p(95)<3000'],
+    'http_req_duration{name:queue_poll}':  ['p(95)<3000'],
+    'http_req_duration{name:queue_apply}': ['p(95)<5000'],
+    'queue_wait_time': ['p(95)<300000'],
+  },
+};
+
+export function setup() {
+  const testData = setupTestData('FIRST_COME_WITH_QUEUE');
+  const tokens = batchLoginAll(TOTAL_VUS);
+  console.log(`[setup] 2웨이브 구성 — Wave1: ${VU_COUNT}명, Wave2: ${EXTRA_VU_COUNT}명, 총 ${TOTAL_VUS}명`);
+  return { tokens, eventIds: testData.eventIds, paceMap: testData.paceMap };
+}
+
+export default function (data) {
+  if (__ITER > 0) {
+    sleep(HOLD_SEC);
+    return;
+  }
+
+  let totalRetries = 0;
+
+  const token = data.tokens[String(__VU)];
+  if (!token) {
+    errorLog(__VU, '토큰 미획득, 건너뜀');
+    return;
+  }
+
+  const isWave2 = __VU > VU_COUNT;
+  const eventId = data.eventIds.FIRST_COME_WITH_QUEUE;
+  const { courseId, paceId } = assignPace(__VU, data.paceMap[String(eventId)]);
+  const headers = authHeaders(token);
+
+  // Wave 2: TTL 만료 대기 후 시작
+  if (isWave2) {
+    sleep(RETRY_WAIT_SEC);
+  }
+
+  // 재고 조회
+  const stockRes = http.get(
+    `${BASE_URL}/main/events/${eventId}/entries/stock-check?paceId=${paceId}`,
+    { headers, tags: { name: 'stock_check' } }
+  );
+  check(stockRes, {
+    'stock-check 200': (r) => r.status === 200,
+  });
+
+  // 토큰 검증 (Wave 1만 — Wave 2는 스킵하여 시간 절약)
+  if (!isWave2) {
+    const noAuthEnterRes = http.post(
+      `${BASE_URL}/queue/enter`,
+      JSON.stringify({ paceId }),
+      {
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer invalid-token' },
+        tags: { name: 'neg_no_auth_queue' },
+        responseCallback: http.expectedStatuses(401),
+      }
+    );
+    check(noAuthEnterRes, { 'invalid JWT → queue 401': (r) => r.status === 401 });
+  }
+
+  // 대기열 진입 (최대 3회 재시도)
+  const { res: enterRes, retries: enterRetries } = withRetry(
+    () => http.post(
+      `${BASE_URL}/queue/enter`,
+      JSON.stringify({ paceId }),
+      { headers, tags: { name: 'queue_enter' } }
+    ),
+    { maxRetries: 3, backoffSec: 2, name: '대기열 진입', vu: __VU }
+  );
+  totalRetries += enterRetries;
+
+  check(enterRes, { 'queue enter 200': (r) => r.status === 200 });
+  if (enterRes.status !== 200) {
+    errorLog(__VU, `대기열 진입 실패 (${enterRes.status})`);
+    return;
+  }
+
+  // 대기열 폴링 (PASS까지)
+  const startWait = Date.now();
+  let passed = false;
+  let passToken = null;
+  let pollCount = 0;
+
+  for (let i = 0; i < QUEUE_MAX_POLL_COUNT; i++) {
+    sleep(QUEUE_POLL_INTERVAL_SEC);
+    pollCount++;
+
+    const statusRes = http.get(
+      `${BASE_URL}/queue/status?paceId=${paceId}`,
+      { headers, tags: { name: 'queue_poll' } }
+    );
+
+    if (statusRes.status === 200) {
+      try {
+        const body = statusRes.json();
+        if (body.data && body.data.status === 'PASS') {
+          passed = true;
+          passToken = body.data.passToken;
+          queueWaitTime.add(Date.now() - startWait);
+          queuePassCount.add(1);
+          break;
+        }
+      } catch (e) { /* 다음 폴링 계속 */ }
+    }
+  }
+
+  if (!passed) {
+    queueTimeoutCount.add(1);
+    errorLog(__VU, `대기열 타임아웃 (${pollCount}회 폴링)`);
+    return;
+  }
+
+  // 대기열 토큰 검증 (Wave 1만)
+  if (!isWave2) {
+    const noQueueTokenRes = http.post(
+      `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
+      JSON.stringify({ courseId, paceId }),
+      {
+        headers,
+        tags: { name: 'neg_no_queue_token' },
+        responseCallback: http.expectedStatuses(429),
+      }
+    );
+    check(noQueueTokenRes, { 'no queue token → 429': (r) => r.status === 429 });
+  }
+
+  // ── 선착순 신청 + 결제 루프 ──
+  const applyHeaders = Object.assign({}, headers, { 'X-Queue-Token': passToken });
+
+  for (let round = 0; round <= RETRY_MAX_ROUNDS; round++) {
+    if (round > 0) sleep(RETRY_WAIT_SEC);
+
+    const { res: applyRes, retries: applyRetries } = withRetry(
+      () => http.post(
+        `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
+        JSON.stringify({ courseId, paceId }),
+        {
+          headers: applyHeaders,
+          tags: { name: 'queue_apply' },
+          responseCallback: http.expectedStatuses(200, 400, 409, 429),
+        }
+      ),
+      { maxRetries: 1, backoffSec: 2, name: '선착순 신청', vu: __VU }
+    );
+    totalRetries += applyRetries;
+
+    if (applyRes.status === 429) {
+      unexpectedErr.add(1);
+      errorLog(__VU, `passToken 만료 (429, 라운드 ${round})`);
+      break;
+    }
+
+    if (applyRes.status === 200) {
+      reserveSuccess.add(1);
+
+      // Wave 1: 이탈/확정 판단 / Wave 2: 전원 결제확정
+      if (!isWave2 && Math.random() < PAYMENT_DROPOUT_RATIO) {
+        paymentDropout.add(1);
+        resultLog(__VU, `결제 이탈 (라운드 ${round})`, totalRetries);
+        break;
+      }
+
+      const confirmRes = http.post(
+        `${BASE_URL}/main/internal/load-test/confirm-reservation`,
+        JSON.stringify({ paceId }),
+        { headers, tags: { name: 'confirm_reservation' } }
+      );
+
+      if (confirmRes.status === 200) {
+        if (isWave2) {
+          wave2Confirmed.add(1);
+          resultLog(__VU, `Wave2 결제 확정 (라운드 ${round})`, totalRetries);
+        } else {
+          paymentConfirmed.add(1);
+          resultLog(__VU, `결제 확정 (라운드 ${round})`, totalRetries);
+        }
+      } else {
+        unexpectedErr.add(1);
+        errorLog(__VU, `결제 확정 실패 (${confirmRes.status}, 라운드 ${round})`);
+      }
+      break;
+
+    } else if (applyRes.status === 409) {
+      try {
+        const code = applyRes.json().code;
+        if (code === 'ENT_010') {
+          alreadyReserved.add(1);
+        }
+        if (round === RETRY_MAX_ROUNDS) {
+          soldOut.add(1);
+          resultLog(__VU, `최종 매진 (${code})`, totalRetries);
+        }
+      } catch (e) {
+        if (round === RETRY_MAX_ROUNDS) {
+          soldOut.add(1);
+          resultLog(__VU, '최종 매진 (409)', totalRetries);
+        }
+      }
+
+    } else {
+      unexpectedErr.add(1);
+      errorLog(__VU, `예상 외 에러 (${applyRes.status}, 라운드 ${round})`);
+      break;
+    }
+  }
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/controller/LoadTestController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/controller/LoadTestController.java
@@ -1,0 +1,59 @@
+package com.kt.onrace.domain.loadtest.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.onrace.common.logging.annotation.ApiLog;
+import com.kt.onrace.common.response.ApiResponse;
+import com.kt.onrace.domain.loadtest.dto.LoadTestConfirmRequest;
+import com.kt.onrace.domain.loadtest.dto.LoadTestSetupRequest;
+import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse;
+import com.kt.onrace.domain.loadtest.service.LoadTestService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+/**
+ * 부하테스트 데이터 셋업 API
+ * local 프로필에서만 활성화
+ */
+@Profile("local")
+@ApiLog
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/load-test")
+public class LoadTestController {
+
+	private final LoadTestService loadTestService;
+
+	/**
+	 * 부하테스트 전체 데이터 셋업
+	 * - 유저 3만명 (멱등)
+	 * - 이벤트 3개 + 코스 + 페이스 + 재고 + 판매정보 (삭제 후 재등록)
+	 * - Redis flushDB + 재고 초기화 + 대기열 활성화
+	 */
+	@PostMapping("/setup")
+	public ApiResponse<LoadTestSetupResponse> setup(
+		@RequestBody @Valid LoadTestSetupRequest request
+	) {
+		return ApiResponse.success(loadTestService.setup(request));
+	}
+
+	/**
+	 * 테스트 전용 예약 확정 (Toss 결제 우회)
+	 * EntryService.confirmReservation()을 직접 호출하여
+	 * RESERVED → APPLIED 상태 전환 + 재고 확정 처리
+	 */
+	@PostMapping("/confirm-reservation")
+	public ApiResponse<Void> confirmReservation(
+		@RequestHeader("X-User-Id") Long userId,
+		@RequestBody @Valid LoadTestConfirmRequest request
+	) {
+		loadTestService.confirmReservation(userId, request.paceId());
+		return ApiResponse.success(null);
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestConfirmRequest.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestConfirmRequest.java
@@ -1,0 +1,9 @@
+package com.kt.onrace.domain.loadtest.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LoadTestConfirmRequest(
+	@NotNull(message = "페이스 ID는 필수입니다")
+	Long paceId
+) {
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestSetupRequest.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestSetupRequest.java
@@ -1,0 +1,45 @@
+package com.kt.onrace.domain.loadtest.dto;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
+public record LoadTestSetupRequest(
+	@Pattern(regexp = "LOTTERY|FIRST_COME_NO_QUEUE|FIRST_COME_WITH_QUEUE",
+		message = "시나리오 타입은 LOTTERY, FIRST_COME_NO_QUEUE, FIRST_COME_WITH_QUEUE 중 하나여야 합니다")
+	String scenarioType, // null이면 전체 이벤트 생성 (하위 호환)
+
+	@Min(value = 10, message = "총 사용자 수는 10 이상이어야 합니다")
+	@Max(value = 30000, message = "총 사용자 수는 30000 이하여야 합니다")
+	int totalUsers,
+
+	@Min(value = 1, message = "경쟁률은 1 이상이어야 합니다")
+	@Max(value = 10, message = "경쟁률은 10 이하여야 합니다")
+	int competitionRatio,
+
+	@Min(value = 1, message = "인기 페이스 수는 1 이상이어야 합니다")
+	@Max(value = 3, message = "인기 페이스 수는 3 이하여야 합니다")
+	int hotPaceCount,
+
+	@DecimalMin(value = "0.01", message = "인기 페이스 재고 비율은 0.01 이상이어야 합니다")
+	@DecimalMax(value = "0.8", message = "인기 페이스 재고 비율은 0.8 이하여야 합니다")
+	double hotStockRatio,
+
+	@Min(value = 15, message = "총 재고는 15(페이스 수) 이상이어야 합니다")
+	Integer totalStock, // null이면 totalUsers/competitionRatio 기반 자동 계산
+
+	@Min(value = 0, message = "인기 코스 인덱스는 0 이상이어야 합니다")
+	@Max(value = 2, message = "인기 코스 인덱스는 2 이하여야 합니다 (0=풀코스, 1=하프코스, 2=10km)")
+	Integer hotCourseIndex, // null이면 기존 랜덤 선정
+
+	@Min(value = 0, message = "인기 페이스 인덱스는 0 이상이어야 합니다")
+	@Max(value = 4, message = "인기 페이스 인덱스는 4 이하여야 합니다 (0=3분, 1=4분, 2=5분, 3=6분, 4=7분)")
+	Integer hotPaceIndex, // hotCourseIndex와 함께 지정 → 해당 코스-페이스 1개를 hot으로 고정
+
+	@DecimalMin(value = "0.0", message = "사전정보 저장 비율은 0.0 이상이어야 합니다")
+	@DecimalMax(value = "1.0", message = "사전정보 저장 비율은 1.0 이하여야 합니다")
+	Double preSaveRatio // null이면 사전저장 건너뜀, 0.7이면 70% 유저 사전저장
+) {
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestSetupResponse.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestSetupResponse.java
@@ -1,0 +1,33 @@
+package com.kt.onrace.domain.loadtest.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.Builder;
+
+@Builder
+public record LoadTestSetupResponse(
+	int userCount,
+	boolean userSkipped,
+	int totalStock,
+	boolean redisInitialized,
+	Map<String, Long> eventIds,
+	Map<String, PaceMapEntry> paceMap,
+	int preSaveCount
+) {
+
+	@Builder
+	public record PaceMapEntry(
+		List<PaceRef> hot,
+		List<PaceRef> others
+	) {
+	}
+
+	@Builder
+	public record PaceRef(
+		long courseId,
+		long paceId,
+		int stock
+	) {
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/service/LoadTestService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/service/LoadTestService.java
@@ -49,6 +49,9 @@ public class LoadTestService {
 	private static final int TOTAL_PACES = 15; // 코스 3개 x 페이스 5개
 	private static final String BCRYPT_HASH = "$2a$10$HWNLFZOjTELM0EaGC14xCeXLBC4RhgmlctVcED4/8MCM8KQ9y4xQS";
 	private static final String TEST_EVENT_PREFIX = "k6 부하테스트";
+	private static final String SCENARIO_LOTTERY = "LOTTERY";
+	private static final String SCENARIO_FC_NO_QUEUE = "FIRST_COME_NO_QUEUE";
+	private static final String SCENARIO_FC_WITH_QUEUE = "FIRST_COME_WITH_QUEUE";
 
 	// ================================================================
 	// 전체 셋업 (단일 API)
@@ -105,27 +108,27 @@ public class LoadTestService {
 		Map<String, PaceMapEntry> paceMap = new LinkedHashMap<>();
 
 		// 응모
-		if (type == null || "LOTTERY".equals(type)) {
+		if (type == null || SCENARIO_LOTTERY.equals(type)) {
 			long lotteryId = insertEvent("k6 부하테스트 - 응모신청", "LOTTERY", false, "'2026-12-31 23:59:59'");
-			eventIds.put("LOTTERY", lotteryId);
+			eventIds.put(SCENARIO_LOTTERY, lotteryId);
 			paceMap.put(String.valueOf(lotteryId),
 				setupCoursesAndPaces(lotteryId, hotIndices, hotStockEach, otherStockEach));
 			insertSalesInfo(lotteryId, "2026-서울-0001");
 		}
 
 		// 선착순 대기열X
-		if (type == null || "FIRST_COME_NO_QUEUE".equals(type)) {
+		if (type == null || SCENARIO_FC_NO_QUEUE.equals(type)) {
 			long fcNoQueueId = insertEvent("k6 부하테스트 - 선착순(대기열X)", "FIRST_COME", false, "NULL");
-			eventIds.put("FIRST_COME_NO_QUEUE", fcNoQueueId);
+			eventIds.put(SCENARIO_FC_NO_QUEUE, fcNoQueueId);
 			paceMap.put(String.valueOf(fcNoQueueId),
 				setupCoursesAndPaces(fcNoQueueId, hotIndices, hotStockEach, otherStockEach));
 			insertSalesInfo(fcNoQueueId, "2026-서울-0002");
 		}
 
 		// 선착순 대기열O
-		if (type == null || "FIRST_COME_WITH_QUEUE".equals(type)) {
+		if (type == null || SCENARIO_FC_WITH_QUEUE.equals(type)) {
 			long fcWithQueueId = insertEvent("k6 부하테스트 - 선착순(대기열O)", "FIRST_COME", true, "NULL");
-			eventIds.put("FIRST_COME_WITH_QUEUE", fcWithQueueId);
+			eventIds.put(SCENARIO_FC_WITH_QUEUE, fcWithQueueId);
 			paceMap.put(String.valueOf(fcWithQueueId),
 				setupCoursesAndPaces(fcWithQueueId, hotIndices, hotStockEach, otherStockEach));
 			insertSalesInfo(fcWithQueueId, "2026-서울-0003");
@@ -138,8 +141,8 @@ public class LoadTestService {
 		for (Long id : eventIds.values()) {
 			eventStockInitializer.initializeEventStock(id);
 		}
-		if (eventIds.containsKey("FIRST_COME_WITH_QUEUE")) {
-			eventService.enableQueue(eventIds.get("FIRST_COME_WITH_QUEUE"));
+		if (eventIds.containsKey(SCENARIO_FC_WITH_QUEUE)) {
+			eventService.enableQueue(eventIds.get(SCENARIO_FC_WITH_QUEUE));
 		}
 
 		// 6. 사전정보 저장 (preSaveRatio가 지정된 경우)
@@ -261,9 +264,8 @@ public class LoadTestService {
 
 	private void cleanupEntries() {
 		int deleted = jdbcTemplate.update("""
-			DELETE FROM entry WHERE user_id IN (
-				SELECT id FROM user WHERE email LIKE 'k6user%@test.com'
-			)
+			DELETE FROM entry
+			WHERE user_id IN (SELECT id FROM user WHERE email LIKE 'k6user%@test.com')
 			""");
 		log.info("[LoadTest] 이전 테스트 entry 삭제 — {}건", deleted);
 	}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/service/LoadTestService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/service/LoadTestService.java
@@ -1,0 +1,527 @@
+package com.kt.onrace.domain.loadtest.service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.onrace.domain.entry.service.EntryService;
+import com.kt.onrace.domain.event.entity.EventAppType;
+import com.kt.onrace.domain.event.service.EventService;
+import com.kt.onrace.domain.event.service.EventStockInitializer;
+import com.kt.onrace.domain.loadtest.dto.LoadTestSetupRequest;
+import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse;
+import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse.PaceMapEntry;
+import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse.PaceRef;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 부하테스트 데이터 자동 셋업 서비스
+ * 모든 ID는 auto_increment — 환경에 무관하게 동작
+ */
+@Slf4j
+@Profile("local")
+@Service
+@RequiredArgsConstructor
+public class LoadTestService {
+
+	private final JdbcTemplate jdbcTemplate;
+	private final RedissonClient redissonClient;
+	private final EventStockInitializer eventStockInitializer;
+	private final EventService eventService;
+	private final EntryService entryService;
+
+	private static final int TOTAL_USERS = 30000;
+	private static final int TOTAL_PACES = 15; // 코스 3개 x 페이스 5개
+	private static final String BCRYPT_HASH = "$2a$10$HWNLFZOjTELM0EaGC14xCeXLBC4RhgmlctVcED4/8MCM8KQ9y4xQS";
+	private static final String TEST_EVENT_PREFIX = "k6 부하테스트";
+
+	// ================================================================
+	// 전체 셋업 (단일 API)
+	// ================================================================
+
+	@Transactional
+	public LoadTestSetupResponse setup(LoadTestSetupRequest request) {
+		int totalUsers = request.totalUsers();
+		int competitionRatio = request.competitionRatio();
+		int hotPaceCount = request.hotPaceCount();
+		double hotStockRatio = request.hotStockRatio();
+
+		// HOT 페이스 인덱스 선정 (고정 지정 또는 랜덤) — 재고 계산 전에 결정
+		Set<Integer> hotIndices;
+		if (request.hotCourseIndex() != null && request.hotPaceIndex() != null) {
+			int globalIndex = request.hotCourseIndex() * 5 + request.hotPaceIndex();
+			hotIndices = Set.of(globalIndex);
+			hotPaceCount = 1; // 고정 지정 시 1개로 오버라이드
+			log.info("[LoadTest] HOT 페이스 고정 지정 — courseIndex={}, paceIndex={}, globalIndex={}",
+				request.hotCourseIndex(), request.hotPaceIndex(), globalIndex);
+		} else {
+			hotIndices = pickRandomHotIndices(hotPaceCount);
+		}
+		log.info("[LoadTest] HOT 페이스 인덱스: {}", hotIndices);
+
+		// 재고 산정 (직접 지정 시 해당 값 사용, 미지정 시 자동 계산)
+		int totalStock = request.totalStock() != null
+			? request.totalStock()
+			: Math.max(TOTAL_PACES, totalUsers / competitionRatio);
+		int hotTotalStock = (int)(totalStock * hotStockRatio);
+		int otherTotalStock = totalStock - hotTotalStock;
+		int hotStockEach = Math.max(1, hotTotalStock / hotPaceCount);
+		int otherPaceCount = TOTAL_PACES - hotPaceCount;
+		int otherStockEach = otherPaceCount > 0 ? Math.max(1, otherTotalStock / otherPaceCount) : 0;
+
+		log.info("[LoadTest] 셋업 시작 — totalUsers={}, competitionRatio={}, hotPaceCount={}, hotStockRatio={}",
+			totalUsers, competitionRatio, hotPaceCount, hotStockRatio);
+		log.info("[LoadTest] 재고 산정 — totalStock={}, hotStockEach={} x {}개, otherStockEach={} x {}개",
+			totalStock, hotStockEach, hotPaceCount, otherStockEach, otherPaceCount);
+
+		// 1. 유저 셋업 (멱등)
+		boolean userSkipped = setupUsers();
+
+		// 2. 이전 테스트 entry 삭제 (k6 테스트 유저 기준)
+		cleanupEntries();
+
+		// 3. 이벤트 데이터 삭제 (타이틀 기반 조회)
+		cleanupEventData();
+
+		// 4. 이벤트 생성 → auto ID 반환 → 코스/페이스/재고/판매정보 연쇄 등록
+		//    scenarioType이 지정되면 해당 이벤트만, null이면 전체 3개 생성
+		String type = request.scenarioType();
+		Map<String, Long> eventIds = new LinkedHashMap<>();
+		Map<String, PaceMapEntry> paceMap = new LinkedHashMap<>();
+
+		// 응모
+		if (type == null || "LOTTERY".equals(type)) {
+			long lotteryId = insertEvent("k6 부하테스트 - 응모신청", "LOTTERY", false, "'2026-12-31 23:59:59'");
+			eventIds.put("LOTTERY", lotteryId);
+			paceMap.put(String.valueOf(lotteryId),
+				setupCoursesAndPaces(lotteryId, hotIndices, hotStockEach, otherStockEach));
+			insertSalesInfo(lotteryId, "2026-서울-0001");
+		}
+
+		// 선착순 대기열X
+		if (type == null || "FIRST_COME_NO_QUEUE".equals(type)) {
+			long fcNoQueueId = insertEvent("k6 부하테스트 - 선착순(대기열X)", "FIRST_COME", false, "NULL");
+			eventIds.put("FIRST_COME_NO_QUEUE", fcNoQueueId);
+			paceMap.put(String.valueOf(fcNoQueueId),
+				setupCoursesAndPaces(fcNoQueueId, hotIndices, hotStockEach, otherStockEach));
+			insertSalesInfo(fcNoQueueId, "2026-서울-0002");
+		}
+
+		// 선착순 대기열O
+		if (type == null || "FIRST_COME_WITH_QUEUE".equals(type)) {
+			long fcWithQueueId = insertEvent("k6 부하테스트 - 선착순(대기열O)", "FIRST_COME", true, "NULL");
+			eventIds.put("FIRST_COME_WITH_QUEUE", fcWithQueueId);
+			paceMap.put(String.valueOf(fcWithQueueId),
+				setupCoursesAndPaces(fcWithQueueId, hotIndices, hotStockEach, otherStockEach));
+			insertSalesInfo(fcWithQueueId, "2026-서울-0003");
+		}
+
+		int actualTotalStock = totalStock * eventIds.size();
+
+		// 5. Redis flushDB → 재고 초기화 → 대기열 활성화 (해당 이벤트만)
+		flushRedis();
+		for (Long id : eventIds.values()) {
+			eventStockInitializer.initializeEventStock(id);
+		}
+		if (eventIds.containsKey("FIRST_COME_WITH_QUEUE")) {
+			eventService.enableQueue(eventIds.get("FIRST_COME_WITH_QUEUE"));
+		}
+
+		// 6. 사전정보 저장 (preSaveRatio가 지정된 경우)
+		int preSaveCount = 0;
+		if (request.preSaveRatio() != null && request.preSaveRatio() > 0) {
+			preSaveCount = batchPreSave(request.preSaveRatio(), totalUsers, eventIds, paceMap);
+		}
+
+		log.info("[LoadTest] 셋업 완료 — eventIds={}, totalStock={}, preSaveCount={}", eventIds, actualTotalStock, preSaveCount);
+
+		return LoadTestSetupResponse.builder()
+			.userCount(TOTAL_USERS)
+			.userSkipped(userSkipped)
+			.totalStock(actualTotalStock)
+			.redisInitialized(true)
+			.eventIds(eventIds)
+			.paceMap(paceMap)
+			.preSaveCount(preSaveCount)
+			.build();
+	}
+
+	// ================================================================
+	// 테스트 전용 예약 확정 (Toss 결제 우회)
+	// ================================================================
+
+	@Transactional
+	public void confirmReservation(Long userId, Long paceId) {
+		entryService.confirmReservation(userId, paceId, EventAppType.FIRST_COME);
+	}
+
+	// ================================================================
+	// 랜덤 HOT 페이스 인덱스 선정
+	// ================================================================
+
+	private Set<Integer> pickRandomHotIndices(int hotPaceCount) {
+		List<Integer> allIndices = IntStream.range(0, TOTAL_PACES)
+			.boxed()
+			.collect(Collectors.toCollection(ArrayList::new));
+		Collections.shuffle(allIndices, ThreadLocalRandom.current());
+		return new HashSet<>(allIndices.subList(0, hotPaceCount));
+	}
+
+	// ================================================================
+	// 유저 셋업 (멱등)
+	// ================================================================
+
+	private boolean setupUsers() {
+		Integer existing = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM user WHERE email LIKE 'k6user%@test.com'",
+			Integer.class
+		);
+
+		if (existing != null && existing >= TOTAL_USERS) {
+			log.info("[LoadTest] 유저 이미 존재 ({}명), 스킵", existing);
+			return true;
+		}
+
+		log.info("[LoadTest] 유저 등록 시작 (기존 {}명 → {}명)", existing, TOTAL_USERS);
+
+		// 기존 부분 데이터 정리
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			jdbcTemplate.update(
+				"DELETE FROM term_user WHERE user_id IN (SELECT id FROM user WHERE email LIKE 'k6user%@test.com')");
+			jdbcTemplate.update(
+				"DELETE FROM members WHERE id IN (SELECT id FROM user WHERE email LIKE 'k6user%@test.com')");
+			jdbcTemplate.update("DELETE FROM user WHERE email LIKE 'k6user%@test.com'");
+		} finally {
+			jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+		}
+
+		// CTE 재귀 깊이 설정
+		jdbcTemplate.execute("SET SESSION cte_max_recursion_depth = 31000");
+
+		// 유저 생성 (auto_increment ID)
+		jdbcTemplate.update("""
+			INSERT INTO user (email, name, password, phone_number, gender, birthdate,
+			  auth_provider, role, status, verification_status, marketing_consent, is_deleted,
+			  created_at, updated_at)
+			WITH RECURSIVE seq AS (
+			  SELECT 1 AS n UNION ALL SELECT n + 1 FROM seq WHERE n < ?
+			)
+			SELECT
+			  CONCAT('k6user', LPAD(n, 5, '0'), '@test.com'),
+			  CONCAT('K6User', LPAD(n, 5, '0')),
+			  ?,
+			  CONCAT('010', LPAD(n, 8, '0')),
+			  IF(MOD(n, 2) = 0, 'MALE', 'FEMALE'),
+			  DATE_ADD('1990-01-01', INTERVAL MOD(n, 3650) DAY),
+			  'LOCAL', 'USER', 'ACTIVE', 'VERIFIED', 0, 0,
+			  NOW(), NOW()
+			FROM seq
+			""", TOTAL_USERS, BCRYPT_HASH);
+
+		// Members 생성 (user.id 조회 후 등록)
+		jdbcTemplate.update("""
+			INSERT INTO members (id, is_deleted, created_at, updated_at)
+			SELECT id, false, NOW(), NOW()
+			FROM user WHERE email LIKE 'k6user%@test.com'
+			""");
+
+		// 필수 약관 동의
+		jdbcTemplate.update("""
+			INSERT INTO term_user (user_id, term_version_id, agreed, agreed_at, created_at, updated_at)
+			SELECT u.id, tv.id, 1, NOW(), NOW(), NOW()
+			FROM user u
+			JOIN term_version tv ON tv.active = 1
+			JOIN term_master tm ON tv.term_master_id = tm.id AND tm.required = 1
+			WHERE u.email LIKE 'k6user%@test.com'
+			""");
+
+		log.info("[LoadTest] 유저 등록 완료 ({}명)", TOTAL_USERS);
+		return false;
+	}
+
+	// ================================================================
+	// Entry 삭제 (k6 테스트 유저 기준 — 모든 이벤트 대상)
+	// ================================================================
+
+	private void cleanupEntries() {
+		int deleted = jdbcTemplate.update("""
+			DELETE FROM entry WHERE user_id IN (
+				SELECT id FROM user WHERE email LIKE 'k6user%@test.com'
+			)
+			""");
+		log.info("[LoadTest] 이전 테스트 entry 삭제 — {}건", deleted);
+	}
+
+	// ================================================================
+	// 이벤트 데이터 정리 (타이틀 기반 조회)
+	// ================================================================
+
+	private void cleanupEventData() {
+		List<Long> eventIds = jdbcTemplate.queryForList(
+			"SELECT id FROM event WHERE title LIKE ?", Long.class, TEST_EVENT_PREFIX + "%"
+		);
+
+		if (eventIds.isEmpty()) {
+			log.info("[LoadTest] 기존 테스트 이벤트 없음, 정리 스킵");
+			return;
+		}
+
+		String ids = eventIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+		log.info("[LoadTest] 기존 테스트 이벤트 정리: {}", ids);
+
+		jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+		try {
+			// entry 삭제
+			jdbcTemplate.update("DELETE FROM entry WHERE event_id IN (" + ids + ")");
+
+			// event_stock 삭제 (pace → course → event 조인)
+			jdbcTemplate.update("""
+				DELETE es FROM event_stock es
+				INNER JOIN event_pace ep ON es.event_pace_id = ep.id
+				INNER JOIN event_course ec ON ep.course_id = ec.id
+				WHERE ec.event_id IN (%s)
+				""".formatted(ids));
+
+			// event_pace 삭제
+			jdbcTemplate.update("""
+				DELETE ep FROM event_pace ep
+				INNER JOIN event_course ec ON ep.course_id = ec.id
+				WHERE ec.event_id IN (%s)
+				""".formatted(ids));
+
+			// 나머지 삭제
+			jdbcTemplate.update("DELETE FROM event_sales_info WHERE event_id IN (" + ids + ")");
+			jdbcTemplate.update("DELETE FROM event_course WHERE event_id IN (" + ids + ")");
+			jdbcTemplate.update("DELETE FROM event WHERE id IN (" + ids + ")");
+		} finally {
+			jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+		}
+
+		log.info("[LoadTest] 이벤트 데이터 정리 완료");
+	}
+
+	// ================================================================
+	// 이벤트 생성 (auto ID → LAST_INSERT_ID 반환)
+	// ================================================================
+
+	private long insertEvent(String title, String appType, boolean isQueue, String lotteryAnnouncedAt) {
+		jdbcTemplate.update("""
+			INSERT INTO event (title, type, app_type, event_at, app_start_at, app_end_at,
+			  region, venue, lottery_announced_at, notice, is_view, is_deleted, sold_out, is_queue,
+			  created_at, updated_at) VALUES
+			(?, 'MARATHON', ?,
+			  '2026-06-01 08:00:00', '2026-01-01 00:00:00', '2026-12-31 23:59:59',
+			  'SEOUL', 'k6 테스트 전용', %s,
+			  ?, true, false, false, ?, NOW(), NOW())
+			""".formatted(lotteryAnnouncedAt),
+			title, appType, "k6 부하테스트용 이벤트", isQueue);
+
+		return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
+	}
+
+	// ================================================================
+	// 코스 + 페이스 + 재고 연쇄 등록, paceMap 구축
+	// ================================================================
+
+	private PaceMapEntry setupCoursesAndPaces(long eventId, Set<Integer> hotIndices,
+		int hotStockEach, int otherStockEach) {
+		// 코스 3개 등록 (풀코스, 하프코스, 10km 순서)
+		insertCourses(eventId);
+		List<Long> courseIds = jdbcTemplate.queryForList(
+			"SELECT id FROM event_course WHERE event_id = ? ORDER BY id", Long.class, eventId);
+
+		String[] courseTypes = {"풀코스", "하프코스", "10km"};
+		List<PaceRef> hotPaces = new ArrayList<>();
+		List<PaceRef> otherPaces = new ArrayList<>();
+
+		int globalPaceIndex = 0;
+
+		for (int i = 0; i < courseIds.size(); i++) {
+			long courseId = courseIds.get(i);
+
+			// 페이스 5개 등록 (capacity = 재고와 동일하게 설정)
+			insertPaces(courseId, courseTypes[i]);
+			List<Long> paceIds = jdbcTemplate.queryForList(
+				"SELECT id FROM event_pace WHERE course_id = ? ORDER BY id", Long.class, courseId);
+
+			// 재고 등록 + paceMap 구축
+			for (int j = 0; j < paceIds.size(); j++) {
+				long paceId = paceIds.get(j);
+				boolean isHot = hotIndices.contains(globalPaceIndex);
+				int stock = isHot ? hotStockEach : otherStockEach;
+
+				insertStock(paceId, stock);
+				updatePaceCapacity(paceId, stock);
+
+				PaceRef ref = PaceRef.builder()
+					.courseId(courseId)
+					.paceId(paceId)
+					.stock(stock)
+					.build();
+
+				if (isHot) {
+					hotPaces.add(ref);
+				} else {
+					otherPaces.add(ref);
+				}
+
+				globalPaceIndex++;
+			}
+		}
+
+		return PaceMapEntry.builder().hot(hotPaces).others(otherPaces).build();
+	}
+
+	private void insertCourses(long eventId) {
+		jdbcTemplate.update("""
+			INSERT INTO event_course (event_id, name, map_url, distance_meter, price, altitude, course_route, time_limit, water_source, created_at, updated_at) VALUES
+			(?, '풀코스', NULL, 42195, 70000, 50, 'k6-test-route', 360, 5, NOW(), NOW()),
+			(?, '하프코스', NULL, 21097, 50000, 30, 'k6-test-route', 240, 3, NOW(), NOW()),
+			(?, '10km', NULL, 10000, 35000, 20, 'k6-test-route', 120, 2, NOW(), NOW())
+			""", eventId, eventId, eventId);
+	}
+
+	private void insertPaces(long courseId, String courseType) {
+		switch (courseType) {
+			case "풀코스" -> jdbcTemplate.update("""
+				INSERT INTO event_pace (course_id, name, hour, minutes, capacity, created_at, updated_at) VALUES
+				(?, '3분 페이스', 2, 7, 0, NOW(), NOW()),
+				(?, '4분 페이스', 2, 49, 0, NOW(), NOW()),
+				(?, '5분 페이스', 3, 31, 0, NOW(), NOW()),
+				(?, '6분 페이스', 4, 13, 0, NOW(), NOW()),
+				(?, '7분 페이스', 4, 55, 0, NOW(), NOW())
+				""", courseId, courseId, courseId, courseId, courseId);
+			case "하프코스" -> jdbcTemplate.update("""
+				INSERT INTO event_pace (course_id, name, hour, minutes, capacity, created_at, updated_at) VALUES
+				(?, '3분 페이스', 1, 3, 0, NOW(), NOW()),
+				(?, '4분 페이스', 1, 24, 0, NOW(), NOW()),
+				(?, '5분 페이스', 1, 45, 0, NOW(), NOW()),
+				(?, '6분 페이스', 2, 7, 0, NOW(), NOW()),
+				(?, '7분 페이스', 2, 28, 0, NOW(), NOW())
+				""", courseId, courseId, courseId, courseId, courseId);
+			case "10km" -> jdbcTemplate.update("""
+				INSERT INTO event_pace (course_id, name, hour, minutes, capacity, created_at, updated_at) VALUES
+				(?, '3분 페이스', 0, 30, 0, NOW(), NOW()),
+				(?, '4분 페이스', 0, 40, 0, NOW(), NOW()),
+				(?, '5분 페이스', 0, 50, 0, NOW(), NOW()),
+				(?, '6분 페이스', 1, 0, 0, NOW(), NOW()),
+				(?, '7분 페이스', 1, 10, 0, NOW(), NOW())
+				""", courseId, courseId, courseId, courseId, courseId);
+			default -> throw new IllegalArgumentException("알 수 없는 코스 타입: " + courseType);
+		}
+	}
+
+	private void insertStock(long paceId, int stock) {
+		jdbcTemplate.update(
+			"INSERT INTO event_stock (event_pace_id, total_stock, confirmed_stock, version, created_at, updated_at) VALUES (?, ?, 0, 0, NOW(), NOW())",
+			paceId, stock);
+	}
+
+	private void updatePaceCapacity(long paceId, int capacity) {
+		jdbcTemplate.update("UPDATE event_pace SET capacity = ? WHERE id = ?", capacity, paceId);
+	}
+
+	// ================================================================
+	// 판매정보 등록
+	// ================================================================
+
+	private void insertSalesInfo(long eventId, String ecommerceNo) {
+		jdbcTemplate.update("""
+			INSERT INTO event_sales_info (
+			  event_id, is_refundable, is_transferable, is_ecommerce_mediator,
+			  refund_start_at, refund_end_at, non_refundable_at,
+			  cancellation_fee, refund_policy, weather_refund,
+			  delivery_target, delivery_method, delivery_start_at, delivery_end_at,
+			  delivery_fee, delivery_area, delivery_info, address_change_period,
+			  delivery_compensation, seller_name, business_no, ecommerce_no,
+			  customer_service, seller_address, created_at, updated_at
+			) VALUES
+			(?, 1, 0, 0,
+			 '2026-04-01 00:00:00', '2026-06-30 23:59:59', '2026-07-01 00:00:00',
+			 '무료', '대회 7일 전까지 전액 환불', '우천 시 대회 취소 및 전액 환불',
+			 '참가자 본인', '택배', '2026-06-01 00:00:00', '2026-06-30 00:00:00',
+			 '무료', '전국', '레이스킷 배송', '2026-05-15 00:00:00',
+			 '미배송 시 전액 환불', 'KT 온레이스', '000-00-00000', ?,
+			 '1588-0000', '서울특별시 중구 테스트로 1', NOW(), NOW())
+			""", eventId, ecommerceNo);
+	}
+
+	// ================================================================
+	// 사전정보 저장 일괄 INSERT (PRE_SAVED 상태)
+	// ================================================================
+
+	private int batchPreSave(double preSaveRatio, int totalUsers,
+		Map<String, Long> eventIds, Map<String, PaceMapEntry> paceMap) {
+		int preSaveCount = (int)(totalUsers * preSaveRatio);
+		if (preSaveCount == 0) return 0;
+
+		// k6user 유저 ID 조회 (preSaveCount명)
+		List<Long> userIds = jdbcTemplate.queryForList(
+			"SELECT id FROM user WHERE email LIKE 'k6user%@test.com' ORDER BY id LIMIT ?",
+			Long.class, preSaveCount);
+
+		if (userIds.isEmpty()) {
+			log.warn("[LoadTest] 사전정보 저장 대상 유저 없음");
+			return 0;
+		}
+
+		int totalInserted = 0;
+
+		for (Map.Entry<String, Long> eventEntry : eventIds.entrySet()) {
+			long eventId = eventEntry.getValue();
+			PaceMapEntry paceMapEntry = paceMap.get(String.valueOf(eventId));
+
+			// hot + others 합쳐서 전체 페이스 목록
+			List<PaceRef> allPaces = new ArrayList<>();
+			allPaces.addAll(paceMapEntry.hot());
+			allPaces.addAll(paceMapEntry.others());
+
+			// 배치 INSERT (1000건씩)
+			int batchSize = 1000;
+			for (int i = 0; i < userIds.size(); i += batchSize) {
+				int end = Math.min(i + batchSize, userIds.size());
+				StringBuilder sb = new StringBuilder();
+				sb.append("INSERT INTO entry (user_id, event_id, course_id, pace_id, status, created_at, updated_at) VALUES ");
+
+				for (int j = i; j < end; j++) {
+					PaceRef pace = allPaces.get(j % allPaces.size());
+					if (j > i) sb.append(",");
+					sb.append(String.format("(%d, %d, %d, %d, 'PRE_SAVED', NOW(), NOW())",
+						userIds.get(j), eventId, pace.courseId(), pace.paceId()));
+				}
+
+				jdbcTemplate.update(sb.toString());
+				totalInserted += (end - i);
+			}
+		}
+
+		log.info("[LoadTest] 사전정보 저장 완료 — {}건 ({}명 x {}이벤트)",
+			totalInserted, userIds.size(), eventIds.size());
+		return totalInserted;
+	}
+
+	// ================================================================
+	// Redis
+	// ================================================================
+
+	private void flushRedis() {
+		log.info("[LoadTest] Redis flushDB 실행");
+		redissonClient.getKeys().flushdb();
+	}
+}

--- a/backend/main/src/main/resources/application.yml
+++ b/backend/main/src/main/resources/application.yml
@@ -10,6 +10,36 @@ spring:
     username: ${MAIN_DB_USERNAME}
     password: ${MAIN_DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      # maximum-pool-size: 풀에서 유지할 최대 커넥션 수
+      # 범위: 10~100 | 기준: (CPU 코어 수 * 2) + 디스크 수. 일반적으로 10~30 권장
+      # 너무 높으면 DB 쪽 컨텍스트 스위칭 오버헤드 증가, 너무 낮으면 커넥션 대기 발생
+      # 단일 인스턴스: 30~50, K8s 멀티 Pod: 15~30 (총 커넥션 = Pod수 x pool-size < DB max_connections)
+      maximum-pool-size: ${MAIN_HIKARI_MAX_POOL_SIZE:10}
+      # minimum-idle: 풀에서 유지할 최소 유휴 커넥션 수
+      # 범위: 1~maximum-pool-size | 기준: 평상시 동시 DB 접근량
+      # maximum-pool-size와 동일하게 설정하면 고정 풀(커넥션 생성/삭제 없음, 응답 안정적)
+      # 낮게 설정하면 유휴 시 리소스 절약, 트래픽 급증 시 커넥션 생성 지연 발생
+      minimum-idle: ${MAIN_HIKARI_MIN_IDLE:5}
+      # connection-timeout: 풀에서 커넥션을 획득할 때 최대 대기 시간 (ms)
+      # 범위: 250~30000 | 기준: 사용자 체감 응답 시간. 기본값 30초는 부하 시 스레드 고갈 유발
+      # 3000ms(3초) 권장: 못 얻으면 빠르게 실패 → 시스템 보호 (fail-fast)
+      # 너무 짧으면(250ms) 정상 상황에서도 불필요한 실패 발생
+      connection-timeout: ${MAIN_HIKARI_CONNECTION_TIMEOUT:3000}
+      # max-lifetime: 풀에 있는 커넥션의 최대 수명 (ms)
+      # 범위: 30000~3600000 | 기준: DB의 wait_timeout 보다 2~3분 짧게 설정
+      # MySQL wait_timeout 기본 28800초(8시간) → 1800000ms(30분) 충분
+      # 너무 짧으면 불필요한 커넥션 재생성, 너무 길면 stale 커넥션 사용 위험
+      max-lifetime: ${MAIN_HIKARI_MAX_LIFETIME:1800000}
+      # idle-timeout: 유휴 커넥션이 풀에서 제거되기까지의 시간 (ms)
+      # 범위: 10000~max-lifetime | 기준: minimum-idle 이상의 유휴 커넥션만 제거됨
+      # 600000ms(10분) 권장. minimum-idle과 maximum-pool-size가 같으면 이 설정은 무시됨
+      idle-timeout: ${MAIN_HIKARI_IDLE_TIMEOUT:600000}
+      # leak-detection-threshold: 커넥션 누수 감지 임계값 (ms)
+      # 범위: 0(비활성), 2000~ | 기준: 가장 느린 쿼리 실행 시간보다 약간 길게
+      # 이 시간 이상 커넥션을 반환하지 않으면 WARN 로그 출력 (leak 의심)
+      # 부하테스트 시 5000ms(5초), 운영 시 30000ms(30초) 또는 비활성(0) 권장
+      leak-detection-threshold: ${MAIN_HIKARI_LEAK_DETECTION:5000}
 
   jpa:
     hibernate:
@@ -33,6 +63,27 @@ spring:
 server:
   port: ${MAIN_SERVER_PORT:8082}
   forward-headers-strategy: framework
+  tomcat:
+    threads:
+      # max: Tomcat이 요청 처리에 사용할 최대 스레드 수
+      # 범위: 50~800 | 기준: (예상 동시 요청 수) 와 (CPU 코어 수 * 50~100)
+      # DB pool보다 커야 함 (DB 안 쓰는 요청도 처리해야 하므로)
+      # CPU 2코어: 100~200, 4코어: 200~400, 8코어: 400~800
+      # 너무 높으면 컨텍스트 스위칭 오버헤드, 너무 낮으면 요청 대기(accept-count 큐로 넘어감)
+      max: ${MAIN_TOMCAT_MAX_THREADS:300}
+      # min-spare: 항상 유지할 최소 유휴 스레드 수
+      # 범위: 10~max의 25% | 기준: 트래픽 급증 시 스레드 생성 지연 방지
+      # 스레드 생성에는 1~5ms 소요 → 트래픽 스파이크 시 병목
+      min-spare: ${MAIN_TOMCAT_MIN_SPARE_THREADS:50}
+    # accept-count: 모든 스레드가 사용 중일 때 OS 레벨 TCP 대기 큐 크기
+    # 범위: 1~1000 | 기준: 순간 트래픽 스파이크 흡수량. max-threads의 50~100%
+    # 이 큐마저 가득 차면 OS가 연결 거부 (connection refused)
+    accept-count: ${MAIN_TOMCAT_ACCEPT_COUNT:200}
+    # max-connections: NIO 커넥터가 수용할 최대 동시 연결 수
+    # 범위: 1000~65535 | 기준: keep-alive 연결 포함 전체 소켓 수. 기본 8192로 대부분 충분
+    max-connections: ${MAIN_TOMCAT_MAX_CONNECTIONS:8192}
+    # [AWS 배포 시] K8s Pod CPU/메모리 리소스에 맞게 threads.max 조정
+    # Pod CPU 2코어: max=200, 4코어: max=400
 
 jwt:
   secret: ${JWT_SECRET}

--- a/backend/queue/src/main/resources/application.yml
+++ b/backend/queue/src/main/resources/application.yml
@@ -25,6 +25,22 @@ queue:
   interval-ms: ${QUEUE_INTERVAL_MS:3000}
   pass-ttl-seconds: ${QUEUE_PASS_TTL_SECONDS:600}
   token-secret: ${QUEUE_TOKEN_SECRET}
+  # ──── 배치 처리 성능 튜닝 가이드 ────
+  # batch-size: pace당 1회 배치에서 처리할 사용자 수
+  #   범위: 50~2000 | 처리율 = batch-size / (interval-ms / 1000)
+  #   현재: 500 / 2초 = 250명/초/pace
+  #   높이면 처리율 증가, but Redis 단일 명령 실행 시간 증가 (blocking 주의)
+  #
+  # interval-ms: 배치 스케줄러 실행 주기 (fixedDelay)
+  #   범위: 1000~10000 | 줄이면 처리율 증가, Redis 부하 증가
+  #   1000ms 이하 비권장 (분산 락 경합 + Redis CPU 부하)
+  #
+  # pass-ttl-seconds: 통과 토큰 유효 시간 (초)
+  #   범위: 60~1800 | 사용자가 결제까지 완료할 시간 고려
+  #   너무 짧으면 결제 중 만료, 너무 길면 미사용 토큰이 슬롯 점유
+  #
+  # [AWS 배포 시] 30,000 트래픽 시: batch-size=1000, interval-ms=2000 → 500명/초/pace 권장
+  # 복수 pace 운영 시: 총 처리율 = 처리율/pace x pace 수
 
 management:
   endpoints:


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- 시나리오별 단일 이벤트 셋업 (scenarioType 파라미터: LOTTERY / FIRST_COME_NO_QUEUE / FIRST_COME_WITH_QUEUE / null)
- 인기 페이스 고정 지정 (hotCourseIndex + hotPaceIndex → globalIndex 계산)
- 사전정보 저장 일괄 INSERT (preSaveRatio 기반 Entry PRE_SAVED 상태, 1000건 배치)
- 페이스 이름 변경: 자유 → 3분 (3분, 4분, 5분, 6분, 7분 순서 정리)
- enableQueue 조건부 호출 (WITH_QUEUE 이벤트 생성 시에만)
- totalStock 응답 = 재고 × 실제 생성 이벤트 수
- VU 70% hot / 30% others 라운드로빈 배분
- http.batch 기반 병렬 로그인 (50명/배치)
- 응모 시나리오 (전원 신청, 재시도 로직)
- 선착순(대기열X) 2웨이브 (Wave1 30% 이탈 → TTL 대기 → Wave2 재선점)
- 선착순(대기열O) 2웨이브 (대기열 진입→폴링→PASS→예약)
- 수동 SQL 파일 5개 삭제 (setup API로 완전 대체)
- 
## 📸 스크린샷 / 아키텍처 / 로그 (필수)

- UI 변경 시 스크린샷 첨부 (Frontend 필수)
- 로직 변경 시 관련 로그나 다이어그램, 테스트 결과 캡처 첨부 (Backend/Infra 필수)
- _멘토링 피드백: "글보다 그림/화면으로 소통하세요"_

## ❓ 변경 이유 (Why)
- 기획 시나리오(4,500명 동시 접속 / 1,500석 / 특정 코스-페이스 70% 집중 / 70% 사전저장)를 k6로 재현하기 위해 셋업 자동화 및 시나리오별 파라미터 지원 필요
- 기존 수동 SQL 기반 셋업은 고정 ID 의존, 재고/페이스 수정 시 매번 SQL 편집 필요 → API 자동화로 대체
- 시나리오별 단일 이벤트 셋업으로 불필요한 리소스 생성 제거 (이벤트 3개 → 1개)

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
