### PR TITLE
fix(backend): k6 부하테스트 메트릭 및 동시성 이슈 수정

### DIFF
--- a/backend/k6/README.md
+++ b/backend/k6/README.md
@@ -9,14 +9,16 @@ On-Race 마라톤 이벤트 티켓팅 플랫폼 부하 테스트 문서입니다
 
 1. [테스트 시나리오 개요](#1-테스트-시나리오-개요)
 2. [아키텍처 & 테스트 흐름](#2-아키텍처--테스트-흐름)
-3. [사전 준비](#3-사전-준비)
-4. [실행 방법](#4-실행-방법)
-5. [환경변수 레퍼런스](#5-환경변수-레퍼런스)
-6. [시나리오별 실행 예시](#6-시나리오별-실행-예시)
-7. [모니터링 (Prometheus + Grafana)](#7-모니터링-prometheus--grafana)
-8. [결과 검증](#8-결과-검증)
-9. [커스텀 메트릭 레퍼런스](#9-커스텀-메트릭-레퍼런스)
-10. [트러블슈팅](#10-트러블슈팅)
+3. [팀별 역할 & 체크리스트](#3-팀별-역할--체크리스트)
+4. [사전 준비](#4-사전-준비)
+5. [실행 방법](#5-실행-방법)
+6. [환경변수 레퍼런스](#6-환경변수-레퍼런스)
+7. [시나리오별 실행 예시](#7-시나리오별-실행-예시)
+8. [인프라 환경별 설정 가이드](#8-인프라-환경별-설정-가이드)
+9. [모니터링 (Prometheus + Grafana)](#9-모니터링-prometheus--grafana)
+10. [결과 검증 & 리포트 해석](#10-결과-검증--리포트-해석)
+11. [커스텀 메트릭 레퍼런스](#11-커스텀-메트릭-레퍼런스)
+12. [트러블슈팅](#12-트러블슈팅)
 
 ---
 
@@ -28,6 +30,7 @@ On-Race 마라톤 이벤트 티켓팅 플랫폼 부하 테스트 문서입니다
 | 1 | 응모신청 | `01-lottery.js` | 로그인 → 응모 (재고 무제한, 전원 성공) |
 | 2 | 선착순 대기열X | `02-first-come-no-queue.js` | 로그인 → 선착순 → 결제/이탈 → Wave2 재선점 |
 | 3 | 선착순 대기열O | `03-first-come-with-queue.js` | 로그인 → 대기열 → 선착순 → 결제/이탈 → Wave2 재선점 |
+| 4 | 용량(Breakpoint) | `04-breakpoint.js` | 계단형 VU 증가 → 한계점 자동 탐지 (모든 플로우 지원) |
 
 > **시나리오별 단일 이벤트 생성**: 각 시나리오는 자신에 해당하는 이벤트 **1개만** 생성합니다.
 > 예: `01-lottery.js`는 응모 이벤트 1개만, `02-first-come-no-queue.js`는 선착순(대기열X) 이벤트 1개만 생성합니다.
@@ -55,7 +58,7 @@ POST /main/internal/load-test/setup  (scenarioType 지정)
 │ 6. 대기열 활성화 (WITH_QUEUE만)           │
 └─────────────────────────────────────────┘
   ↓
-일괄 로그인 (http.batch)
+일괄 로그인 (http.batch, 50명/배치)
   ↓
 VU 실행 시작
 ```
@@ -80,12 +83,15 @@ Wave 2 (VU VU_COUNT+1 ~ 총VU)
 - Wave 2 인원은 `EXTRA_VU_COUNT` 또는 `VU_COUNT × PAYMENT_DROPOUT_RATIO`로 자동 계산
 - 총 VU = VU_COUNT + EXTRA_VU_COUNT
 
-### 2.3 페이스 배분
+### 2.3 페이스 배분 (70/30 인터리빙)
 
 ```
-전체 VU의 70% (HOT_PACE_RATIO) → 인기 페이스 (라운드로빈)
-전체 VU의 30%                   → 나머지 페이스 (라운드로빈)
+10-VU 블록 단위 인터리빙:
+  블록 내 첫 7명 → 인기 페이스 (라운드로빈)
+  블록 내 나머지 3명 → 일반 페이스 (라운드로빈)
 ```
+
+> Wave2도 동일한 비율로 인기 페이스에 배정되어 HOT 페이스 기아 현상을 방지합니다.
 
 ### 2.4 인기 페이스 재고 배분
 
@@ -96,11 +102,58 @@ Wave 2 (VU VU_COUNT+1 ~ 총VU)
 나머지 재고      = (총재고 - 인기 총재고) ÷ (15 - HOT_PACE_COUNT)
 ```
 
+### 2.5 용량(Breakpoint) 테스트 구조 (시나리오 4)
+
+```
+계단형 VU 증가 (Staircase):
+  500 → 1000 → 1500 → 2000 → ... → BP_MAX_VUS
+  각 단계: ramp 10초 → hold 60초
+
+자동 중단 조건:
+  - error_rate > 5% (30초 유예)
+  - apply_latency p95 > 5000ms (30초 유예)
+
+VU 토큰 순환:
+  30,000명 로그인 풀에서 소수 배수(7919)로 순환
+  → 매 반복마다 다른 유저 사용 → 실제 INSERT 쓰기 부하 유지
+```
+
 ---
 
-## 3. 사전 준비
+## 3. 팀별 역할 & 체크리스트
 
-### 3.1 k6 설치
+### 3.1 개발팀 (Backend)
+
+| 단계 | 작업 | 비고 |
+|------|------|------|
+| **사전** | Gateway rate limiter 주석 처리 | `RequestRateLimiter` 필터 |
+| **사전** | Gateway queue/entry route 주석 해제 | `BotDetectionFilter` 주석 유지 |
+| **사전** | `MAIN_PROFILES_ACTIVE=local` 확인 | Setup API는 local에서만 활성화 |
+| **실행** | 로컬 Docker 환경에서 시나리오 0→1→2→3 순서 실행 | |
+| **실행** | 시나리오 4(Breakpoint)로 단일 인스턴스 한계점 탐지 | |
+| **검증** | 오버셀링 0건, DB-Redis 일치 확인 | teardown 자동 리포트 |
+| **검증** | 동시성 이슈 발견 시 코드 수정 후 재테스트 | |
+| **인수** | Breakpoint 결과 (안정 VU, 안정 RPS) 인프라팀에 전달 | Pod 스케일링 기준값 |
+
+### 3.2 인프라팀 (DevOps / SRE)
+
+| 단계 | 작업 | 비고 |
+|------|------|------|
+| **사전** | EKS/ECS 클러스터 + RDS + ElastiCache 프로비저닝 | t3.micro부터 시작 |
+| **사전** | `.env` 인프라 환경용 복사 & 수정 | [섹션 8](#8-인프라-환경별-설정-가이드) 참조 |
+| **사전** | Prometheus + Grafana 모니터링 스택 배포 | |
+| **1차** | t3.micro 단일 Pod → 시나리오 4(Breakpoint) 실행 | 기준선 측정 |
+| **2차** | t3.small → t3.medium 순서로 스펙 업 테스트 | 스펙별 안정 VU 비교 |
+| **3차** | 최적 스펙에서 Pod 2→4→8 스케일 아웃 테스트 | 선형 확장성 검증 |
+| **4차** | KEDA HPA 설정 후 자동 스케일링 테스트 | CPU/RPS 기반 트리거 |
+| **검증** | Pod별 CPU/메모리, DB 커넥션, Redis 커넥션 모니터링 | Grafana 대시보드 |
+| **산출** | 스펙별 성능 비교표 + 최적 Pod 수 + HPA 설정값 문서화 | |
+
+---
+
+## 4. 사전 준비
+
+### 4.1 k6 설치
 
 ```bash
 # Windows
@@ -113,7 +166,7 @@ brew install k6
 k6 version
 ```
 
-### 3.2 Gateway 설정 변경
+### 4.2 Gateway 설정 변경
 
 `gateway/src/main/resources/application.yml`에서:
 
@@ -121,7 +174,7 @@ k6 version
 2. **queue-route**: 주석 해제, `BotDetectionFilter` 주석 유지
 3. **entry-apply-first-come-route**: 주석 해제, `BotDetectionFilter` 주석 유지
 
-### 3.3 서비스 기동
+### 4.3 서비스 기동
 
 ```bash
 # Docker 전체 빌드 & 실행 (서비스 + 모니터링 스택)
@@ -135,7 +188,7 @@ docker compose ps
 
 ---
 
-## 4. 실행 방법
+## 5. 실행 방법
 
 ### 기본 실행
 
@@ -152,18 +205,19 @@ k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 backend/k6/scenarios/01-lottery.js
 ### 실행 순서 권장
 
 ```
-1. 00-smoke-test.js     ← 환경 검증 (5 VU)
-2. 01-lottery.js        ← 소규모 50~100 VU 검증
-3. 01-lottery.js        ← 목표 규모 (4,500 VU)
-4. 02-first-come-no-queue.js
-5. 03-first-come-with-queue.js
+1. 00-smoke-test.js         ← 환경 검증 (5 VU)
+2. 01-lottery.js             ← 소규모 50~100 VU 검증
+3. 01-lottery.js             ← 목표 규모 (4,500 VU)
+4. 02-first-come-no-queue.js ← 선착순 대기열X
+5. 03-first-come-with-queue.js ← 선착순 대기열O
+6. 04-breakpoint.js          ← 한계점 탐지 (선택)
 ```
 
 > **시나리오 간 별도 초기화 불필요**: 각 시나리오의 setup()이 이전 데이터를 자동 정리합니다.
 
 ---
 
-## 5. 환경변수 레퍼런스
+## 6. 환경변수 레퍼런스
 
 모든 값은 `-e` 플래그로 오버라이드 가능합니다.
 
@@ -216,7 +270,7 @@ k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 backend/k6/scenarios/01-lottery.js
 | `PAYMENT_DROPOUT_RATIO` | `0.3` | Wave 1 결제 이탈률 (30%) |
 | `EXTRA_VU_COUNT` | *(자동)* | Wave 2 추가 인원. 미지정 시 `VU_COUNT × PAYMENT_DROPOUT_RATIO` |
 | `RETRY_MAX_ROUNDS` | `5` | 매진 시 최대 재시도 횟수 |
-| `RETRY_WAIT_SEC` | `18` | 재시도 대기 시간 (TTL 15초 + 여유 3초) |
+| `RETRY_WAIT_SEC` | `18` | Wave2 TTL 만료 대기 (TTL 15초 + 여유 3초) |
 
 ### 대기열 설정 (시나리오 3)
 
@@ -225,32 +279,41 @@ k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 backend/k6/scenarios/01-lottery.js
 | `QUEUE_POLL_SEC` | `2` | 대기열 폴링 간격(초) |
 | `QUEUE_MAX_POLL` | `300` | 최대 폴링 횟수 |
 
-### 로그인 설정
+### 용량(Breakpoint) 테스트 설정 (시나리오 4)
+
+| 변수 | 기본값 | 설명 |
+|------|--------|------|
+| `BP_SCENARIO_FLOW` | `LOTTERY` | 테스트 플로우 (`LOTTERY` / `FIRST_COME` / `FIRST_COME_QUEUE`) |
+| `BP_START_VUS` | `500` | 시작 VU 수 |
+| `BP_STEP_VUS` | `500` | 단계별 VU 증분 |
+| `BP_MAX_VUS` | `5000` | 최대 VU 수 |
+| `BP_STEP_DURATION_SEC` | `60` | 단계 유지 시간(초) |
+| `BP_RAMP_SEC` | `10` | 단계 간 ramp 시간(초) |
+| `BP_ERROR_THRESHOLD` | `0.05` | 에러율 중단 임계값 (5%) |
+| `BP_P95_THRESHOLD_MS` | `5000` | p95 응답시간 중단 임계값 (ms) |
+| `BP_LOGIN_POOL` | `30000` | 로그인 유저 풀 크기 |
+
+### 로그인 & 기타
 
 | 변수 | 기본값 | 설명 |
 |------|--------|------|
 | `LOGIN_TIMEOUT` | `120s` | 로그인 HTTP 타임아웃 |
 | `LOGIN_BATCH_SIZE` | `50` | 배치 로그인 단위 |
-
-### 기타
-
-| 변수 | 기본값 | 설명 |
-|------|--------|------|
 | `HOT_PACE_RATIO` | `0.7` | VU의 70%가 인기 페이스 대상 |
 
 ---
 
-## 6. 시나리오별 실행 예시
+## 7. 시나리오별 실행 예시
 
-### 6.1 스모크 테스트
+### 7.1 스모크 테스트
 
 ```bash
 k6 run backend/k6/scenarios/00-smoke-test.js
 ```
 
-### 6.2 시나리오 1: 응모신청 (01-lottery)
+### 7.2 시나리오 1: 응모신청 (01-lottery)
 
-> 재고 제한 없음. 전원 신청 성공이 기대됩니다.
+> 재고 제한 없음. 전원 응모 성공이 기대됩니다.
 
 ```bash
 # 소규모 검증 (100명)
@@ -269,7 +332,7 @@ k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.
   -e LOGIN_TIMEOUT=180s backend/k6/scenarios/01-lottery.js
 ```
 
-### 6.3 시나리오 2: 선착순 대기열X (02-first-come-no-queue)
+### 7.3 시나리오 2: 선착순 대기열X (02-first-come-no-queue)
 
 > 2웨이브 구조. 재고 소진 시 매진, 이탈 재고 재순환 검증.
 
@@ -290,7 +353,7 @@ k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.
   -e LOGIN_TIMEOUT=180s backend/k6/scenarios/02-first-come-no-queue.js
 ```
 
-### 6.4 시나리오 3: 선착순 대기열O (03-first-come-with-queue)
+### 7.4 시나리오 3: 선착순 대기열O (03-first-come-with-queue)
 
 > 2웨이브 구조 + 대기열 경유. PASS 수신 후 선착순 신청.
 
@@ -312,7 +375,28 @@ k6 run -e VU_COUNT=30000 -e RAMP_UP_SEC=180 -e HOLD_SEC=600 -e PRE_SAVE_RATIO=0.
   backend/k6/scenarios/03-first-come-with-queue.js
 ```
 
-### 6.5 고급 옵션 조합 예시
+### 7.5 시나리오 4: 용량(Breakpoint) 테스트 (04-breakpoint)
+
+> 계단형 VU 증가로 서버 한계점을 자동 탐지합니다.
+
+```bash
+# 응모 플로우 (기본)
+k6 run backend/k6/scenarios/04-breakpoint.js
+
+# 선착순 대기열X (재고 충분하게 설정)
+k6 run -e BP_SCENARIO_FLOW=FIRST_COME -e TOTAL_STOCK=999999 \
+  backend/k6/scenarios/04-breakpoint.js
+
+# 선착순 대기열O
+k6 run -e BP_SCENARIO_FLOW=FIRST_COME_QUEUE -e TOTAL_STOCK=999999 \
+  backend/k6/scenarios/04-breakpoint.js
+
+# 세밀한 단계 (100 VU 씩 증가, 최대 3,000)
+k6 run -e BP_START_VUS=100 -e BP_STEP_VUS=100 -e BP_MAX_VUS=3000 \
+  -e BP_STEP_DURATION_SEC=90 backend/k6/scenarios/04-breakpoint.js
+```
+
+### 7.6 고급 옵션 조합 예시
 
 ```bash
 # 인기 페이스 고정 (10km 코스 / 5분 페이스) + 재고 직접 지정
@@ -332,7 +416,178 @@ k6 run -e VU_COUNT=4500 -e PAYMENT_DROPOUT_RATIO=0.5 -e EXTRA_VU_COUNT=1000 \
 
 ---
 
-## 7. 모니터링 (Prometheus + Grafana)
+## 8. 인프라 환경별 설정 가이드
+
+### 8.1 AWS 스펙별 .env 설정 추천
+
+인프라팀은 t3.micro부터 시작하여 점진적으로 스펙을 올리며 테스트합니다.
+
+#### t3.micro (2 vCPU, 1GB RAM) — 기준선 측정용
+
+```env
+# HikariCP (메모리 제약 → 최소화)
+MAIN_HIKARI_MAX_POOL_SIZE=10
+MAIN_HIKARI_MIN_IDLE=5
+AUTH_HIKARI_MAX_POOL_SIZE=5
+AUTH_HIKARI_MIN_IDLE=3
+MAIN_HIKARI_CONNECTION_TIMEOUT=3000
+
+# Tomcat (2 vCPU → 스레드 제한)
+MAIN_TOMCAT_MAX_THREADS=50
+MAIN_TOMCAT_MIN_SPARE_THREADS=10
+MAIN_TOMCAT_ACCEPT_COUNT=30
+AUTH_TOMCAT_MAX_THREADS=30
+AUTH_TOMCAT_MIN_SPARE_THREADS=5
+AUTH_TOMCAT_ACCEPT_COUNT=15
+
+# JVM (1GB RAM → 힙 512MB)
+MAIN_JAVA_OPTS=-Xms256m -Xmx512m
+AUTH_JAVA_OPTS=-Xms128m -Xmx256m
+```
+
+```bash
+# Breakpoint 실행 (낮은 시작점)
+k6 run -e BP_START_VUS=50 -e BP_STEP_VUS=50 -e BP_MAX_VUS=500 \
+  -e BP_STEP_DURATION_SEC=60 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/04-breakpoint.js
+```
+
+#### t3.small (2 vCPU, 2GB RAM)
+
+```env
+MAIN_HIKARI_MAX_POOL_SIZE=15
+MAIN_HIKARI_MIN_IDLE=8
+AUTH_HIKARI_MAX_POOL_SIZE=10
+AUTH_HIKARI_MIN_IDLE=5
+MAIN_TOMCAT_MAX_THREADS=100
+MAIN_TOMCAT_MIN_SPARE_THREADS=20
+AUTH_TOMCAT_MAX_THREADS=60
+AUTH_TOMCAT_MIN_SPARE_THREADS=10
+MAIN_JAVA_OPTS=-Xms512m -Xmx1024m
+AUTH_JAVA_OPTS=-Xms256m -Xmx512m
+```
+
+```bash
+k6 run -e BP_START_VUS=100 -e BP_STEP_VUS=100 -e BP_MAX_VUS=1000 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/04-breakpoint.js
+```
+
+#### t3.medium (2 vCPU, 4GB RAM)
+
+```env
+MAIN_HIKARI_MAX_POOL_SIZE=20
+MAIN_HIKARI_MIN_IDLE=10
+AUTH_HIKARI_MAX_POOL_SIZE=15
+AUTH_HIKARI_MIN_IDLE=8
+MAIN_TOMCAT_MAX_THREADS=200
+MAIN_TOMCAT_MIN_SPARE_THREADS=40
+AUTH_TOMCAT_MAX_THREADS=100
+AUTH_TOMCAT_MIN_SPARE_THREADS=20
+MAIN_JAVA_OPTS=-Xms1024m -Xmx2048m
+AUTH_JAVA_OPTS=-Xms512m -Xmx1024m
+```
+
+```bash
+k6 run -e BP_START_VUS=200 -e BP_STEP_VUS=200 -e BP_MAX_VUS=2000 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/04-breakpoint.js
+```
+
+#### t3.large (2 vCPU, 8GB RAM)
+
+```env
+MAIN_HIKARI_MAX_POOL_SIZE=30
+MAIN_HIKARI_MIN_IDLE=15
+AUTH_HIKARI_MAX_POOL_SIZE=20
+AUTH_HIKARI_MIN_IDLE=10
+MAIN_TOMCAT_MAX_THREADS=300
+MAIN_TOMCAT_MIN_SPARE_THREADS=60
+AUTH_TOMCAT_MAX_THREADS=150
+AUTH_TOMCAT_MIN_SPARE_THREADS=30
+MAIN_JAVA_OPTS=-Xms2048m -Xmx4096m
+AUTH_JAVA_OPTS=-Xms1024m -Xmx2048m
+```
+
+```bash
+k6 run -e BP_START_VUS=300 -e BP_STEP_VUS=300 -e BP_MAX_VUS=3000 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/04-breakpoint.js
+```
+
+### 8.2 스케일 아웃 테스트 가이드
+
+단일 Pod Breakpoint 결과를 기반으로 스케일 아웃을 테스트합니다.
+
+#### 단계 1: 단일 Pod 기준선 확인
+
+```bash
+# 예: t3.medium 단일 Pod에서 안정 VU = 800 확인
+k6 run -e BP_SCENARIO_FLOW=FIRST_COME_QUEUE -e TOTAL_STOCK=999999 \
+  -e BP_START_VUS=100 -e BP_STEP_VUS=100 -e BP_MAX_VUS=2000 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/04-breakpoint.js
+```
+
+#### 단계 2: Pod 수 증가하며 부하 테스트 (시나리오 1~3)
+
+```bash
+# Pod 2개 → VU 1,600 (안정 VU × 2)
+kubectl scale deployment main --replicas=2
+k6 run -e VU_COUNT=1600 -e RAMP_UP_SEC=60 -e PRE_SAVE_RATIO=0.7 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/03-first-come-with-queue.js
+
+# Pod 4개 → VU 3,200
+kubectl scale deployment main --replicas=4
+k6 run -e VU_COUNT=3200 -e RAMP_UP_SEC=90 -e PRE_SAVE_RATIO=0.7 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/03-first-come-with-queue.js
+
+# Pod 8개 → VU 4,500 (기획 목표)
+kubectl scale deployment main --replicas=8
+k6 run -e VU_COUNT=4500 -e RAMP_UP_SEC=60 -e HOLD_SEC=300 -e PRE_SAVE_RATIO=0.7 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/03-first-come-with-queue.js
+```
+
+#### 단계 3: HPA 자동 스케일링 검증
+
+```bash
+# HPA 설정 후 점진적 부하 증가로 자동 스케일링 동작 확인
+k6 run -e BP_SCENARIO_FLOW=FIRST_COME_QUEUE -e TOTAL_STOCK=999999 \
+  -e BP_START_VUS=500 -e BP_STEP_VUS=500 -e BP_MAX_VUS=10000 \
+  -e BP_STEP_DURATION_SEC=120 \
+  -e BASE_URL=http://<ALB_ENDPOINT> \
+  backend/k6/scenarios/04-breakpoint.js
+```
+
+> HPA 테스트 시 `BP_STEP_DURATION_SEC`을 120초 이상으로 설정하여 스케일링 반응 시간을 확보합니다.
+
+### 8.3 RDS 설정 참고
+
+| 인스턴스 | max_connections (자동) | 권장 Pod 수 (Pool 20 기준) |
+|----------|----------------------|--------------------------|
+| db.t3.micro | ~66 | 2~3 |
+| db.t3.small | ~150 | 5~6 |
+| db.t3.medium | ~312 | 12~14 |
+| db.r5.large | ~1365 | 50+ |
+
+> **공식**: `max_connections ≈ {DBInstanceClassMemory/12582880}` (RDS 자동 계산)
+> 모든 Pod의 HikariCP pool 합계가 max_connections의 80%를 넘지 않도록 설정합니다.
+
+### 8.4 ElastiCache(Redis) 설정 참고
+
+| 항목 | 권장값 | 비고 |
+|------|--------|------|
+| 인스턴스 | cache.t3.micro 이상 | 대기열 + 재고 관리 |
+| maxmemory-policy | `noeviction` | 재고 데이터 유실 방지 |
+| notify-keyspace-events | `Ex` | TTL 만료 이벤트 수신 필수 |
+
+---
+
+## 9. 모니터링 (Prometheus + Grafana)
 
 ### Prometheus 연동 실행
 
@@ -345,15 +600,59 @@ k6 run -o experimental-prometheus-rw \
 
 ### Grafana 대시보드
 
-- Grafana: `http://localhost:3000` (admin / admin)
+- Grafana: `http://localhost:9091` (admin / admin)
 - k6 기본 대시보드 import: Dashboard ID `18030`
 - Loki 로그 확인: Explore → Loki → `{container="main"}` 등
 
+### docker-compose.yml 모니터링 스택
+
+```yaml
+# 이미 포함된 서비스:
+# - prometheus (9090): 15초 간격으로 gateway/auth/main/queue actuator 스크래핑
+# - grafana (9091): 시각화
+# - loki (9092): 로그 수집
+# - promtail: Docker 컨테이너 로그 → Loki 전송 (onrace.log.collect=true 라벨 기반)
+```
+
 ---
 
-## 8. 결과 검증
+## 10. 결과 검증 & 리포트 해석
 
-### 8.1 기대 결과
+### 10.1 리포트 지표 설명
+
+테스트 완료 시 자동 출력되는 리포트의 각 항목 의미:
+
+#### 성능 지표
+
+| 항목 | 의미 |
+|------|------|
+| 총 요청 | 테스트 중 발생한 전체 HTTP 요청 수 (폴링, 재시도 포함) |
+| 평균 RPS | 초당 요청 처리량 |
+| 에러율 | 서버 에러(5xx) 비율. 비즈니스 에러(409, 400)는 미포함 |
+| p50 / p90 / p95 | 신청(apply) 응답시간 백분위수 |
+
+#### 비즈니스 지표 (선착순)
+
+| 항목 | 의미 |
+|------|------|
+| 선점 성공 | apply 200 응답 (RESERVED 상태). 결제 전 단계 |
+| 중복/매진 | 이미 신청(409) 또는 유효성 검증 실패(400) |
+| Wave1 결제 확정 | Wave1 유저 중 결제까지 완료 (APPLIED 상태) |
+| Wave2 결제 확정 | Wave2 유저가 이탈 재고를 재선점 후 결제 완료 |
+| 총 결제 확정 | Wave1 + Wave2 합산. **DB APPLIED 수와 일치해야 함** |
+| 결제 이탈 | Wave1에서 선점 후 결제하지 않은 건 (TTL 만료 후 재고 반환) |
+| 재선점 | 이탈 재고 중 Wave2가 실제로 재선점한 건. 재선점률 = 재선점 / 이탈 |
+| 매진 차단 | 최대 재시도 후에도 매진으로 종료된 VU 수 |
+| 비즈니스 차단 | 대기열 중복 진입(409), passToken 만료(429) 등 |
+| 서버 에러 | 예상 외 HTTP 에러 (5xx 등) |
+
+#### 비즈니스 지표 (응모)
+
+| 항목 | 의미 |
+|------|------|
+| 응모 성공 | apply 200 응답 (APPLIED 상태). 재고 무제한이므로 전원 성공 기대 |
+
+### 10.2 기대 결과
 
 #### 시나리오 1: 응모신청
 
@@ -367,10 +666,11 @@ k6 run -o experimental-prometheus-rw \
 
 | 항목 | 기대값 (VU=4,500 / 재고=1,500) |
 |------|-------------------------------|
-| Wave 1 선점 성공 | ~1,500건 |
-| Wave 1 결제확정 | ~1,050건 (70%) |
-| Wave 1 결제이탈 | ~450건 (30%) |
-| Wave 2 재선점+확정 | ~450건 |
+| Wave1 선점 성공 | ~1,500건 |
+| Wave1 결제 확정 | ~1,050건 (70%) |
+| 결제 이탈 | ~450건 (30%) |
+| Wave2 재선점 | ~450건 (재선점률 ~100%) |
+| 총 결제 확정 | ~1,500건 |
 | **오버셀링** | **0건** |
 | p95 응답시간 | < 3초 |
 
@@ -378,15 +678,38 @@ k6 run -o experimental-prometheus-rw \
 
 | 항목 | 기대값 (VU=4,500 / 재고=1,500) |
 |------|-------------------------------|
-| PASS 수신 | 전원 |
-| Wave 1 선점 성공 | ~1,500건 |
-| Wave 1 결제확정 | ~1,050건 (70%) |
-| Wave 1 결제이탈 | ~450건 (30%) |
-| Wave 2 재선점+확정 | ~450건 |
+| 대기열 PASS | 전원 (5,850명) |
+| Wave1 선점 성공 | ~1,500건 |
+| Wave1 결제 확정 | ~1,050건 (70%) |
+| 결제 이탈 | ~450건 (30%) |
+| Wave2 재선점 | ~450건 (재선점률 ~100%) |
+| 총 결제 확정 | ~1,500건 |
 | **오버셀링** | **0건** |
 | queue_wait_time p95 | < 5분 |
 
-### 8.2 검증 쿼리 (동적 ID)
+> **재선점률이 100% 미만인 경우**: 페이스 배분 불일치 또는 테스트 시간 초과(interrupted iterations)로 인한 정상 현상입니다. 오버셀링 0건이면 동시성 제어는 정상입니다.
+
+### 10.3 재고 검증 리포트 (teardown 자동 출력)
+
+```
+========================================
+         재고 검증 리포트
+========================================
+이벤트 ID: 103
+
+[DB]    총 재고: 1491  |  확정: 1481
+[Redis] 잔여:   10  |  확정: 1481
+[Entry] PRE_SAVED: 3018  |  RESERVED: 453  |  APPLIED: 1481
+
+오버셀링:     없음 (OK)       ← 반드시 OK
+DB-Redis 일치: 일치 (OK)       ← 반드시 OK
+```
+
+- **오버셀링**: APPLIED + RESERVED > 총 재고이면 `!! 발생 !!` 표시
+- **DB-Redis 일치**: DB 확정 수 ≠ Redis 확정 수이면 `!! 불일치 !!` 표시
+- **RESERVED**: 이탈자 (결제 미완료). TTL 만료 후 재고는 반환되지만 Entry 상태는 RESERVED 유지
+
+### 10.4 검증 쿼리 (동적 ID)
 
 테스트 후 아래 쿼리로 결과를 검증합니다. Setup API가 동적 ID를 생성하므로, 먼저 이벤트 ID를 확인하세요.
 
@@ -435,45 +758,59 @@ GROUP BY user_id, event_id HAVING cnt > 1;
 
 ---
 
-## 9. 커스텀 메트릭 레퍼런스
+## 11. 커스텀 메트릭 레퍼런스
 
-### 시나리오 1: 응모신청
+> 아래 메트릭은 모두 **k6 클라이언트 사이드 메트릭**입니다. 서버 코드가 아닌 k6 스크립트 내에서 HTTP 응답 코드 기반으로 집계됩니다.
+> 서버 사이드 메트릭(JVM, DB 커넥션, 요청 처리시간 등)은 Spring Actuator + Prometheus가 자동 수집하며 `/actuator/prometheus` 엔드포인트에서 확인 가능합니다.
+>
+> **서버 대응 메트릭**이 있는 항목은 `/actuator/prometheus`에서 교차 검증할 수 있습니다.
 
-| 메트릭 | 타입 | 설명 |
-|--------|------|------|
-| `lottery_apply_success` | Counter | 응모 성공 수 |
-| `lottery_apply_fail` | Counter | 응모 실패 수 |
+### 공통 (모든 시나리오)
 
-### 시나리오 2: 선착순 대기열X
+| 메트릭 | 타입 | 설명 | 서버 대응 메트릭 |
+|--------|------|------|-----------------|
+| `apply_ok` | Counter | 신청/선점 성공 수 (HTTP 200) | `entry_apply_total{result="success"}` |
+| `apply_dup` | Counter | 중복/매진 수 (HTTP 409, 400) | `entry_apply_total{result="duplicate\|sold_out"}` |
+| `apply_latency` | Trend | 신청 응답시간 (ms) | — |
+| `error_rate` | Rate | 서버 에러 비율 | — |
+| `unexpected_error` | Counter | 예상 외 에러 수 | — |
 
-| 메트릭 | 타입 | 설명 |
-|--------|------|------|
-| `firstcome_reserve_success` | Counter | 선점 성공 수 |
-| `firstcome_payment_confirmed` | Counter | Wave 1 결제확정 수 |
-| `firstcome_payment_dropout` | Counter | Wave 1 결제이탈 수 |
-| `firstcome_wave2_confirmed` | Counter | Wave 2 재선점+확정 수 |
-| `firstcome_sold_out` | Counter | 최종 매진 수 |
-| `firstcome_already_reserved` | Counter | 중복 신청(409) 수 |
-| `firstcome_unexpected_error` | Counter | 예상 외 에러 수 |
+### 선착순 전용 (시나리오 2, 3)
 
-### 시나리오 3: 선착순 대기열O
+| 메트릭 | 타입 | 설명 | 서버 대응 메트릭 |
+|--------|------|------|-----------------|
+| `confirm_ok` | Counter | Wave1 결제 확정 수 | `entry_confirm_total` |
+| `payment_dropout` | Counter | Wave1 결제 이탈 수 | `entry_rollback_total` |
+| `wave2_ok` | Counter | Wave2 재선점+결제 확정 수 | `entry_confirm_total` (Wave 구분 없음) |
+| `sold_out` | Counter | 최종 매진 수 | `stock_reserve_total{result="sold_out"}` |
 
-| 메트릭 | 타입 | 설명 |
-|--------|------|------|
-| `queue_wait_time` | Trend | 대기열 대기 시간(ms) |
-| `queue_pass_count` | Counter | PASS 수신 수 |
-| `queue_timeout_count` | Counter | 대기열 타임아웃 수 |
-| `queue_reserve_success` | Counter | 선점 성공 수 |
-| `queue_payment_confirmed` | Counter | Wave 1 결제확정 수 |
-| `queue_payment_dropout` | Counter | Wave 1 결제이탈 수 |
-| `queue_wave2_confirmed` | Counter | Wave 2 재선점+확정 수 |
-| `queue_sold_out` | Counter | 최종 매진 수 |
-| `queue_already_reserved` | Counter | 중복 신청(409) 수 |
-| `queue_unexpected_error` | Counter | 예상 외 에러 수 |
+### 대기열 전용 (시나리오 3, 4)
+
+| 메트릭 | 타입 | 설명 | 서버 대응 메트릭 |
+|--------|------|------|-----------------|
+| `queue_wait_time` | Trend | 대기열 대기 시간 (ms) | — |
+| `queue_pass` | Counter | PASS 수신 수 | `queue_pass_total` |
+| `queue_timeout` | Counter | 대기열 타임아웃 수 | — |
+| `blocked` | Counter | 비즈니스 차단 수 (409, 429) | — |
+
+### HTTP 태그별 응답시간 필터
+
+| 태그 | 시나리오 | 설명 |
+|------|---------|------|
+| `stock_check` | 1, 2, 3 | 재고 조회 |
+| `firstcome_apply` | 2 | 선착순 신청 |
+| `queue_enter` | 3 | 대기열 진입 |
+| `queue_poll` | 3 | 대기열 폴링 |
+| `queue_apply` | 3 | 대기열 경유 선착순 신청 |
+| `confirm_reservation` | 2, 3 | 결제 확정 |
+| `bp_apply` | 4 | Breakpoint 신청 |
+| `bp_confirm` | 4 | Breakpoint 결제 확정 |
+| `bp_queue_enter` | 4 | Breakpoint 대기열 진입 |
+| `bp_queue_poll` | 4 | Breakpoint 대기열 폴링 |
 
 ---
 
-## 10. 트러블슈팅
+## 12. 트러블슈팅
 
 ### Setup API 500 에러
 
@@ -505,6 +842,18 @@ docker compose build --no-cache && docker compose up -d
 - VU 30,000 기준 토큰 저장 메모리 약 150MB
 - k6 실행 머신의 여유 메모리 확인
 
+### AWS 환경에서 Connection Refused
+
+- Security Group에서 Gateway 포트 (30000) 인바운드 허용 확인
+- ALB Target Group 헬스체크 경로: `/actuator/health`
+- k6 실행 머신 → ALB 네트워크 경로 확인
+
+### Pod 스케일 아웃 시 DB 커넥션 고갈
+
+- 모든 Pod의 HikariCP pool 합계 < RDS max_connections 확인
+- 공식: `Pod 수 × MAIN_HIKARI_MAX_POOL_SIZE < max_connections × 0.8`
+- t3.micro RDS는 max_connections ~66이므로 Pod 3개 × Pool 20 = 60으로 제한
+
 ---
 
 ## 프로젝트 구조
@@ -515,13 +864,16 @@ k6/
 │   ├── 00-smoke-test.js              # 스모크 테스트 (5 VU)
 │   ├── 01-lottery.js                 # 응모신청
 │   ├── 02-first-come-no-queue.js     # 선착순 대기열X (2웨이브)
-│   └── 03-first-come-with-queue.js   # 선착순 대기열O (2웨이브)
+│   ├── 03-first-come-with-queue.js   # 선착순 대기열O (2웨이브)
+│   └── 04-breakpoint.js             # 용량(Breakpoint) 테스트
 ├── lib/
 │   ├── config.js        # 환경변수 & 기본값
 │   ├── setup.js         # Setup API 호출 (데이터 자동 셋업)
 │   ├── auth.js          # 로그인 & 토큰 관리 (배치 로그인)
-│   ├── distribution.js  # VU → 페이스 배분 (70/30 HOT 배분)
-│   ├── retry.js         # HTTP 재시도 래퍼
-│   └── log.js           # 로깅 유틸
+│   ├── distribution.js  # VU → 페이스 배분 (70/30 인터리빙)
+│   ├── retry.js         # HTTP 재시도 래퍼 (5xx만, 지수 백오프)
+│   ├── log.js           # 로깅 유틸
+│   ├── breakpoint.js    # 계단형 스테이지 생성
+│   └── report.js        # 통합 리포트 템플릿
 └── README.md            # 이 문서
 ```

--- a/backend/k6/lib/breakpoint.js
+++ b/backend/k6/lib/breakpoint.js
@@ -1,0 +1,46 @@
+// ========================================================
+// 용량(Breakpoint) 테스트 헬퍼 라이브러리
+//
+// - 계단형 stages 자동 생성
+// - VU별 유저 토큰 순환 (30,000명 풀 활용)
+// ========================================================
+
+// ================================================================
+// 계단형 stages 생성
+// ================================================================
+
+/**
+ * ramping-vus용 계단형(Staircase) stages 배열 생성
+ *
+ * @param {number} startVUs   - 시작 VU 수
+ * @param {number} stepVUs    - 단계별 VU 증분
+ * @param {number} maxVUs     - 최대 VU 수
+ * @param {number} durationSec - 단계 유지 시간 (초)
+ * @param {number} rampSec    - 단계 간 ramp 시간 (초)
+ * @returns {Array<{duration: string, target: number}>}
+ *
+ * 예: start=500, step=500, max=2000, duration=60, ramp=10
+ * → [ {10s, 500}, {60s, 500}, {10s, 1000}, {60s, 1000}, {10s, 1500}, {60s, 1500}, {10s, 2000}, {60s, 2000} ]
+ */
+export function generateStaircaseStages(startVUs, stepVUs, maxVUs, durationSec, rampSec) {
+  const stages = [];
+
+  for (let vus = startVUs; vus <= maxVUs; vus += stepVUs) {
+    stages.push({ duration: `${rampSec}s`, target: vus });
+    stages.push({ duration: `${durationSec}s`, target: vus });
+  }
+
+  return stages;
+}
+
+/**
+ * stages 구성을 사람이 읽을 수 있는 문자열로 변환
+ * 예: "500 → 1000 → 1500 → 2000 VUs"
+ */
+export function describeStages(startVUs, stepVUs, maxVUs) {
+  const steps = [];
+  for (let vus = startVUs; vus <= maxVUs; vus += stepVUs) {
+    steps.push(vus);
+  }
+  return steps.join(' → ') + ' VUs';
+}

--- a/backend/k6/lib/config.js
+++ b/backend/k6/lib/config.js
@@ -52,9 +52,21 @@ export const QUEUE_MAX_POLL_COUNT    = parseInt(__ENV.QUEUE_MAX_POLL || '300');
 // === 결제 이탈 + 2웨이브 설정 ===
 export const PAYMENT_DROPOUT_RATIO = parseFloat(__ENV.PAYMENT_DROPOUT_RATIO || '0.3');  // 30% 이탈
 export const RETRY_MAX_ROUNDS      = parseInt(__ENV.RETRY_MAX_ROUNDS || '5');            // 매진 시 최대 재시도 횟수
-export const RETRY_WAIT_SEC        = parseInt(__ENV.RETRY_WAIT_SEC || '18');             // 재시도 대기 (TTL 15초 + 여유 3초)
+export const RETRY_WAIT_SEC        = parseInt(__ENV.RETRY_WAIT_SEC || '18');             // Wave2 TTL 만료 대기 (TTL 15초 + 여유 3초)
+export const RETRY_DELAY_SEC       = parseInt(__ENV.RETRY_DELAY_SEC || '5');             // 매진 재시도 간격 (라운드 간 대기)
 
 // === Wave 2 추가 인원 (이탈자 재고 재선점) ===
 export const EXTRA_VU_COUNT = __ENV.EXTRA_VU_COUNT != null
   ? parseInt(__ENV.EXTRA_VU_COUNT)
   : Math.ceil(VU_COUNT * PAYMENT_DROPOUT_RATIO);  // 미지정 시 이탈률 기반 자동 계산
+
+// === 용량(Breakpoint) 테스트 설정 ===
+export const BP_START_VUS        = parseInt(__ENV.BP_START_VUS || '500');           // 시작 VU 수
+export const BP_STEP_VUS         = parseInt(__ENV.BP_STEP_VUS || '500');            // 단계별 VU 증분
+export const BP_MAX_VUS          = parseInt(__ENV.BP_MAX_VUS || '5000');            // 최대 VU 수
+export const BP_STEP_DURATION_SEC = parseInt(__ENV.BP_STEP_DURATION_SEC || '60');   // 단계 유지 시간 (초)
+export const BP_RAMP_SEC         = parseInt(__ENV.BP_RAMP_SEC || '10');             // 단계 간 ramp 시간 (초)
+export const BP_ERROR_THRESHOLD  = parseFloat(__ENV.BP_ERROR_THRESHOLD || '0.05'); // 에러율 중단 임계값 (5%)
+export const BP_P95_THRESHOLD_MS = parseInt(__ENV.BP_P95_THRESHOLD_MS || '5000');  // p95 응답시간 중단 임계값 (ms)
+export const BP_SCENARIO_FLOW    = __ENV.BP_SCENARIO_FLOW || 'LOTTERY';            // LOTTERY / FIRST_COME / FIRST_COME_QUEUE
+export const BP_LOGIN_POOL       = parseInt(__ENV.BP_LOGIN_POOL || '30000');       // 로그인 유저 풀 (BP_MAX_VUS와 분리, 쓰기 부하 유지용)

--- a/backend/k6/lib/distribution.js
+++ b/backend/k6/lib/distribution.js
@@ -35,7 +35,7 @@ export function assignPace(vuIndex, paceMapEntry) {
   // 10-VU 블록 단위 인터리브 배분
   // 예: HOT_PACE_RATIO=0.7 → 매 10명 중 앞 7명 HOT, 뒤 3명 Others
   const RATIO_BASE = 10;
-  const hotSlots = Math.round(HOT_PACE_RATIO * RATIO_BASE);
+  const hotSlots = Math.floor(HOT_PACE_RATIO * RATIO_BASE);
   const posInBlock = (vuIndex - 1) % RATIO_BASE;
   const blockNum = Math.floor((vuIndex - 1) / RATIO_BASE);
 

--- a/backend/k6/lib/distribution.js
+++ b/backend/k6/lib/distribution.js
@@ -2,14 +2,26 @@
 // 유저 → 페이스 배분 로직
 // 70% HOT 페이스 집중, 30% 나머지 페이스 분산
 //
+// 10-VU 블록 단위 인터리브 배분:
+//   매 10명 중 앞 7명 → HOT, 뒤 3명 → 나머지
+//   Wave 2 VU(VU_COUNT+1~)도 동일 70/30 비율 보장
+//
 // setup API 응답의 paceMap을 사용하여 동적 배분
 // paceMap[eventId] = { hot: [{ courseId, paceId, stock }], others: [...] }
 // ========================================================
 
-import { HOT_PACE_RATIO, VU_COUNT } from './config.js';
+import { HOT_PACE_RATIO } from './config.js';
 
 /**
- * VU를 페이스에 배분 (동적 paceMap 기반)
+ * VU를 페이스에 배분 (동적 paceMap 기반, 인터리브 70/30)
+ *
+ * 기존 문제: VU 번호 범위 기반 배분(1~hotCutoff → HOT) 시
+ *   Wave 2 VU(VU_COUNT+1~)가 전원 Others로 배분되어
+ *   HOT 페이스 이탈 재고를 Wave 2가 회수하지 못함
+ *
+ * 해결: 10-VU 블록 단위 인터리브 배분으로
+ *   VU 번호와 무관하게 일관된 70/30 비율 보장
+ *
  * @param {number} vuIndex - VU 번호 (1-based, __VU)
  * @param {Object} paceMapEntry - { hot: [{ courseId, paceId }], others: [{ courseId, paceId }, ...] }
  * @returns {{ courseId: number, paceId: number }}
@@ -20,22 +32,29 @@ export function assignPace(vuIndex, paceMapEntry) {
     return { courseId: 0, paceId: 0 };
   }
 
-  const hotCutoff = Math.floor(VU_COUNT * HOT_PACE_RATIO);
+  // 10-VU 블록 단위 인터리브 배분
+  // 예: HOT_PACE_RATIO=0.7 → 매 10명 중 앞 7명 HOT, 뒤 3명 Others
+  const RATIO_BASE = 10;
+  const hotSlots = Math.round(HOT_PACE_RATIO * RATIO_BASE);
+  const posInBlock = (vuIndex - 1) % RATIO_BASE;
+  const blockNum = Math.floor((vuIndex - 1) / RATIO_BASE);
 
-  // 70%: HOT 페이스 (여러 개일 경우 라운드로빈)
-  if (vuIndex <= hotCutoff) {
+  // 블록 내 앞 hotSlots명 → HOT 페이스
+  if (posInBlock < hotSlots) {
     const hotPaces = paceMapEntry.hot;
-    const idx = (vuIndex - 1) % hotPaces.length;
+    const hotSeq = blockNum * hotSlots + posInBlock;
+    const idx = hotSeq % hotPaces.length;
     return { courseId: hotPaces[idx].courseId, paceId: hotPaces[idx].paceId };
   }
 
-  // 30%: 나머지 페이스 라운드로빈
+  // 블록 내 나머지 → Others 페이스 라운드로빈
   const others = paceMapEntry.others;
   if (!others || others.length === 0) {
     const fallback = paceMapEntry.hot[0];
     return { courseId: fallback.courseId, paceId: fallback.paceId };
   }
 
-  const idx = (vuIndex - hotCutoff - 1) % others.length;
+  const otherSeq = blockNum * (RATIO_BASE - hotSlots) + (posInBlock - hotSlots);
+  const idx = otherSeq % others.length;
   return { courseId: others[idx].courseId, paceId: others[idx].paceId };
 }

--- a/backend/k6/lib/report.js
+++ b/backend/k6/lib/report.js
@@ -1,0 +1,278 @@
+// ========================================================
+// 공유 리포트 템플릿 라이브러리
+//
+// 부하 테스트(01~03) + 용량 테스트(04) 공용
+// 성능 지표 + 비즈니스 지표 통합 리포트 생성
+// ========================================================
+
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.1.0/index.js';
+import { describeStages } from './breakpoint.js';
+
+// ================================================================
+// 공통 유틸
+// ================================================================
+
+function fmt(n) {
+  return n != null ? n.toLocaleString() : '0';
+}
+
+function pct(part, total) {
+  if (!total || total === 0) return '0.0';
+  return ((part / total) * 100).toFixed(1);
+}
+
+function counter(metrics, name) {
+  return metrics[name] ? metrics[name].values.count : 0;
+}
+
+function formatDuration(ms) {
+  const sec = ms / 1000;
+  const mins = Math.floor(sec / 60);
+  const secs = Math.round(sec % 60);
+  return `${mins}분 ${secs}초`;
+}
+
+// ================================================================
+// 헤더 섹션
+// ================================================================
+
+function formatLoadTestHeader(config) {
+  const lines = [
+    '',
+    '========================================',
+    '         부하 테스트 리포트',
+    '========================================',
+    `테스트 흐름:   ${config.flow}`,
+    `동시 사용자:   ${fmt(config.vuCount)} VUs`,
+  ];
+  if (config.totalStock != null) {
+    lines.push(`총 재고:       ${fmt(config.totalStock)}석`);
+  }
+  return lines;
+}
+
+function formatBreakpointHeader(config) {
+  const stagesDesc = describeStages(config.startVUs, config.stepVUs, config.maxVUs);
+  return [
+    '',
+    '========================================',
+    '     용량(Breakpoint) 테스트 리포트',
+    '========================================',
+    `테스트 흐름:   ${config.flow}`,
+    `스테이지 구성:  ${stagesDesc}`,
+    `단계 유지:     ${config.stepDurationSec}초 (ramp ${config.rampSec}초)`,
+    `로그인 풀:     ${config.loginPool ? fmt(config.loginPool) + '명' : 'BP_MAX_VUS와 동일'}`,
+    `중단 임계값:   에러율 > ${(config.errorThreshold * 100).toFixed(0)}% 또는 p95 > ${config.p95ThresholdMs}ms`,
+  ];
+}
+
+// ================================================================
+// 성능 지표 섹션
+// ================================================================
+
+function formatPerformanceMetrics(data) {
+  const metrics = data.metrics;
+  const durationMs = data.state.testRunDurationMs;
+  const durationSec = durationMs / 1000;
+
+  const totalReqs = metrics.http_reqs ? metrics.http_reqs.values.count : 0;
+  const avgRPS = totalReqs > 0 ? (totalReqs / durationSec).toFixed(1) : '0';
+  const maxVUs = metrics.vus_max ? metrics.vus_max.values.value : 0;
+
+  // 에러율: error_rate (커스텀 Rate) 또는 http_req_failed (내장)
+  // k6 Rate: add(true)=passes(에러), add(false)=fails(성공)
+  let errorRate, errorCount;
+  if (metrics.error_rate) {
+    errorRate = (metrics.error_rate.values.rate * 100).toFixed(2);
+    errorCount = metrics.error_rate.values.passes || 0;
+  } else {
+    const failed = metrics.http_req_failed ? metrics.http_req_failed.values.rate : 0;
+    errorRate = (failed * 100).toFixed(2);
+    errorCount = metrics.http_req_failed ? metrics.http_req_failed.values.passes || 0 : 0;
+  }
+
+  // 응답시간: apply_latency (커스텀 Trend) 또는 http_req_duration (내장)
+  const latencyMetric = metrics.apply_latency || metrics.http_req_duration;
+  const latency = latencyMetric ? latencyMetric.values : {};
+  const p50 = latency.med != null ? Math.round(latency.med) : '-';
+  const p90 = latency['p(90)'] != null ? Math.round(latency['p(90)']) : '-';
+  const p95 = latency['p(95)'] != null ? Math.round(latency['p(95)']) : '-';
+
+  return {
+    lines: [
+      `테스트 시간:   ${formatDuration(durationMs)}`,
+      '',
+      '성능 지표:',
+      `  총 요청:     ${fmt(totalReqs)}`,
+      `  평균 RPS:    ${avgRPS}`,
+      `  에러율:      ${errorRate}% (${fmt(errorCount)}건)`,
+      `  p50: ${p50}ms  |  p90: ${p90}ms  |  p95: ${p95}ms`,
+    ],
+    // 용량 테스트 결과 판정용 내부 데이터
+    totalReqs,
+    avgRPS,
+    maxVUs,
+    durationSec,
+    errorCount,
+  };
+}
+
+// ================================================================
+// 비즈니스 지표 섹션
+// ================================================================
+
+function formatBusinessMetrics(data, flow) {
+  const m = data.metrics;
+  const lines = ['', '비즈니스 지표:'];
+
+  const applyOk        = counter(m, 'apply_ok');
+  const applyDup       = counter(m, 'apply_dup');
+  const confirmOk      = counter(m, 'confirm_ok');
+  const paymentDropout = counter(m, 'payment_dropout');
+  const wave2Ok        = counter(m, 'wave2_ok');
+  const soldOutCount   = counter(m, 'sold_out');
+  const blockedCount   = counter(m, 'blocked');
+  const unexpectedErr  = counter(m, 'unexpected_error');
+  const queuePassCount = counter(m, 'queue_pass');
+  const queueTimeoutCt = counter(m, 'queue_timeout');
+
+  const totalApply = applyOk + applyDup;
+
+  // 대기열 지표 (FIRST_COME_QUEUE만)
+  if (flow === 'FIRST_COME_QUEUE') {
+    lines.push(`  대기열 통과:    ${fmt(queuePassCount)}건`);
+    lines.push(`  대기열 타임아웃: ${fmt(queueTimeoutCt)}건`);
+
+    // 대기열 대기시간 (Trend)
+    if (m.queue_wait_time) {
+      const wt = m.queue_wait_time.values;
+      const wtMed = wt.med != null ? Math.round(wt.med) : '-';
+      const wt95 = wt['p(95)'] != null ? Math.round(wt['p(95)']) : '-';
+      lines.push(`  대기 시간:      p50=${wtMed}ms  |  p95=${wt95}ms`);
+    }
+  }
+
+  // 신청 지표 (flow별 분기)
+  if (flow === 'LOTTERY') {
+    lines.push(`  응모 성공:      ${fmt(applyOk)}건${totalApply > 0 ? ` (${pct(applyOk, totalApply)}%)` : ''}`);
+  } else {
+    lines.push(`  선점 성공:      ${fmt(applyOk)}건${totalApply > 0 ? ` (${pct(applyOk, totalApply)}%)` : ''}`);
+  }
+  lines.push(`  중복/매진:      ${fmt(applyDup)}건${totalApply > 0 ? ` (${pct(applyDup, totalApply)}%)` : ''}`);
+
+  // 결제 지표 (FIRST_COME / FIRST_COME_QUEUE)
+  if (flow === 'FIRST_COME' || flow === 'FIRST_COME_QUEUE') {
+    const totalConfirm = confirmOk + wave2Ok;
+    lines.push(`  Wave1 결제 확정: ${fmt(confirmOk)}건${applyOk > 0 ? ` (확정률 ${pct(confirmOk, applyOk)}%)` : ''}`);
+    lines.push(`  Wave2 결제 확정: ${fmt(wave2Ok)}건`);
+    lines.push(`  총 결제 확정:   ${fmt(totalConfirm)}건`);
+    lines.push(`  결제 이탈:      ${fmt(paymentDropout)}건`);
+    lines.push(`  재선점:         ${fmt(wave2Ok)}건${paymentDropout > 0 ? ` (재선점률 ${pct(wave2Ok, paymentDropout)}%)` : ''}`);
+    lines.push(`  매진 차단:      ${fmt(soldOutCount)}건`);
+  }
+
+  // 비즈니스 차단 + 서버 에러 (공통)
+  lines.push(`  비즈니스 차단:  ${fmt(blockedCount)}건`);
+  lines.push(`  서버 에러:      ${fmt(unexpectedErr)}건`);
+
+  return lines;
+}
+
+// ================================================================
+// 용량 테스트 결과 판정 섹션
+// ================================================================
+
+function formatBreakpointResult(data, config, perf) {
+  const perStepSec = config.rampSec + config.stepDurationSec;
+  const reachedStep = Math.floor(perf.durationSec / perStepSec) + 1;
+  const totalSteps = Math.ceil((config.maxVUs - config.startVUs) / config.stepVUs) + 1;
+  const reachedVUs = Math.min(
+    config.startVUs + (reachedStep - 1) * config.stepVUs,
+    config.maxVUs
+  );
+
+  const aborted = reachedStep < totalSteps;
+  const stableStep = aborted ? Math.max(1, reachedStep - 1) : reachedStep;
+  const stableVUs = Math.min(
+    config.startVUs + (stableStep - 1) * config.stepVUs,
+    config.maxVUs
+  );
+
+  const lines = [];
+
+  if (aborted) {
+    lines.push('========================================');
+    lines.push(' 한계점 도달 — 임계값 초과로 자동 중단');
+    lines.push('----------------------------------------');
+    lines.push(` 도달 단계:     ${reachedStep}단계 (${reachedVUs} VUs)`);
+    lines.push(` 최대 안정 단계: ${stableStep}단계 (${stableVUs} VUs)`);
+    lines.push(` 안정 RPS:      ~${perf.avgRPS} req/s`);
+    lines.push('========================================');
+    lines.push(` 권장 스케일링 기준값:`);
+    lines.push(`  - Pod당 안정 VU:  ~${stableVUs}`);
+    lines.push(`  - 안전 마진 70%:  ~${Math.round(stableVUs * 0.7)}`);
+    lines.push('========================================');
+  } else {
+    lines.push('========================================');
+    lines.push(' 모든 단계 통과 — 한계점 미도달');
+    lines.push('----------------------------------------');
+    lines.push(` 최종 단계: ${totalSteps}단계 (${config.maxVUs} VUs)`);
+    lines.push(` 안정 RPS: ~${perf.avgRPS} req/s`);
+    lines.push('========================================');
+    lines.push(' BP_MAX_VUS를 늘려 재시도하세요.');
+    lines.push('========================================');
+  }
+
+  return lines;
+}
+
+// ================================================================
+// 최종 리포트 조합
+// ================================================================
+
+/**
+ * handleSummary에서 호출하여 최종 출력 객체 생성
+ *
+ * @param {Object} data   - k6 handleSummary에 전달되는 data 객체
+ * @param {Object} config - 테스트 설정 정보
+ *   config.testType:  'LOAD' | 'BREAKPOINT'
+ *   config.flow:      'LOTTERY' | 'FIRST_COME' | 'FIRST_COME_QUEUE'
+ *   // LOAD 전용
+ *   config.vuCount, config.totalStock
+ *   // BREAKPOINT 전용
+ *   config.startVUs, config.stepVUs, config.maxVUs, config.stepDurationSec,
+ *   config.rampSec, config.errorThreshold, config.p95ThresholdMs, config.loginPool
+ */
+export function buildSummaryOutput(data, config) {
+  // 1. 헤더
+  const header = config.testType === 'BREAKPOINT'
+    ? formatBreakpointHeader(config)
+    : formatLoadTestHeader(config);
+
+  // 2. 성능 지표
+  const perf = formatPerformanceMetrics(data);
+
+  // 3. 비즈니스 지표
+  const business = formatBusinessMetrics(data, config.flow);
+
+  // 4. 용량 테스트 결과 (BREAKPOINT만)
+  const bpResult = config.testType === 'BREAKPOINT'
+    ? formatBreakpointResult(data, config, perf)
+    : ['========================================'];
+
+  // 조합
+  const report = [
+    ...header,
+    ...perf.lines,
+    ...business,
+    '',
+    ...bpResult,
+    '',
+  ].join('\n');
+
+  const defaultSummary = textSummary(data, { indent: '  ', enableColors: true });
+
+  return {
+    stdout: defaultSummary + '\n' + report,
+  };
+}

--- a/backend/k6/scenarios/01-lottery.js
+++ b/backend/k6/scenarios/01-lottery.js
@@ -9,21 +9,25 @@
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { Counter } from 'k6/metrics';
+import { Counter, Rate, Trend } from 'k6/metrics';
 import { batchLoginAll, authHeaders } from '../lib/auth.js';
 import { setupTestData } from '../lib/setup.js';
 import { assignPace } from '../lib/distribution.js';
 import { withRetry } from '../lib/retry.js';
 import { errorLog, resultLog } from '../lib/log.js';
+import { buildSummaryOutput } from '../lib/report.js';
 import {
   BASE_URL, VU_COUNT,
   RAMP_UP_SEC, HOLD_SEC, RAMP_DOWN_SEC,
   SETUP_TIMEOUT_SEC,
 } from '../lib/config.js';
 
-// 커스텀 메트릭
-const applySuccess = new Counter('lottery_apply_success');
-const applyFail    = new Counter('lottery_apply_fail');
+// 커스텀 메트릭 (통일 네이밍)
+const applyOk        = new Counter('apply_ok');
+const applyDup       = new Counter('apply_dup');
+const unexpectedErr  = new Counter('unexpected_error');
+const errorRate      = new Rate('error_rate');
+const applyLatency   = new Trend('apply_latency');
 
 export const options = {
   setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
@@ -89,28 +93,48 @@ export default function (data) {
   check(noAuthRes, { 'invalid JWT → 401': (r) => r.status === 401 });
 
   // 응모 신청
+  const start = Date.now();
   const { res, retries } = withRetry(
     () => http.post(
       `${BASE_URL}/main/events/${eventId}/entries/apply/lottery`,
       JSON.stringify({ courseId, paceId }),
-      { headers, tags: { name: 'lottery_apply' } }
+      {
+        headers,
+        tags: { name: 'lottery_apply' },
+        responseCallback: http.expectedStatuses(200, 400, 409),
+      }
     ),
     { maxRetries: 1, backoffSec: 2, name: '응모 신청', vu: __VU }
   );
+  const elapsed = Date.now() - start;
+  applyLatency.add(elapsed);
 
-  const ok = check(res, {
-    'lottery 200': (r) => r.status === 200,
-    'has entryId': (r) => {
-      try { return r.json().data.entryId != null; }
-      catch (e) { return false; }
-    },
-  });
-
-  if (ok) {
-    applySuccess.add(1);
+  if (res.status === 200) {
+    const ok = check(res, {
+      'has entryId': (r) => {
+        try { return r.json().data.entryId != null; }
+        catch (e) { return false; }
+      },
+    });
+    applyOk.add(1);
+    errorRate.add(false);
     resultLog(__VU, `응모 성공`, retries);
+  } else if (res.status === 400 || res.status === 409) {
+    applyDup.add(1);
+    errorRate.add(false);
+    resultLog(__VU, `이미 신청됨 (${res.status})`, retries);
   } else {
-    applyFail.add(1);
+    unexpectedErr.add(1);
+    errorRate.add(true);
     errorLog(__VU, `응모 실패 (${res.status})`);
   }
+}
+
+// ── handleSummary: 통합 리포트 출력 ──
+export function handleSummary(data) {
+  return buildSummaryOutput(data, {
+    testType: 'LOAD',
+    flow: 'LOTTERY',
+    vuCount: VU_COUNT,
+  });
 }

--- a/backend/k6/scenarios/02-first-come-no-queue.js
+++ b/backend/k6/scenarios/02-first-come-no-queue.js
@@ -10,29 +10,32 @@
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { Counter } from 'k6/metrics';
+import { Counter, Rate, Trend } from 'k6/metrics';
 import { batchLoginAll, authHeaders } from '../lib/auth.js';
 import { setupTestData } from '../lib/setup.js';
 import { assignPace } from '../lib/distribution.js';
 import { withRetry } from '../lib/retry.js';
 import { errorLog, resultLog } from '../lib/log.js';
+import { buildSummaryOutput } from '../lib/report.js';
 import {
   BASE_URL, VU_COUNT, EXTRA_VU_COUNT,
   RAMP_UP_SEC, HOLD_SEC, RAMP_DOWN_SEC,
   SETUP_TIMEOUT_SEC,
-  PAYMENT_DROPOUT_RATIO, RETRY_MAX_ROUNDS, RETRY_WAIT_SEC,
+  PAYMENT_DROPOUT_RATIO, RETRY_MAX_ROUNDS, RETRY_WAIT_SEC, RETRY_DELAY_SEC,
 } from '../lib/config.js';
 
 const TOTAL_VUS = VU_COUNT + EXTRA_VU_COUNT;
 
-// 커스텀 메트릭
-const reserveSuccess   = new Counter('firstcome_reserve_success');
-const paymentConfirmed = new Counter('firstcome_payment_confirmed');
-const paymentDropout   = new Counter('firstcome_payment_dropout');
-const wave2Confirmed   = new Counter('firstcome_wave2_confirmed');
-const soldOut          = new Counter('firstcome_sold_out');
-const alreadyReserved  = new Counter('firstcome_already_reserved');
-const unexpectedErr    = new Counter('firstcome_unexpected_error');
+// 커스텀 메트릭 (통일 네이밍)
+const applyOk        = new Counter('apply_ok');
+const applyDup       = new Counter('apply_dup');
+const confirmOk      = new Counter('confirm_ok');
+const paymentDropout = new Counter('payment_dropout');
+const wave2Ok        = new Counter('wave2_ok');
+const soldOut        = new Counter('sold_out');
+const unexpectedErr  = new Counter('unexpected_error');
+const errorRate      = new Rate('error_rate');
+const applyLatency   = new Trend('apply_latency');
 
 export const options = {
   setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
@@ -108,8 +111,9 @@ export default function (data) {
   let totalRetries = 0;
 
   for (let round = 0; round <= RETRY_MAX_ROUNDS; round++) {
-    if (round > 0) sleep(RETRY_WAIT_SEC);
+    if (round > 0) sleep(RETRY_DELAY_SEC);
 
+    const start = Date.now();
     const { res, retries } = withRetry(
       () => http.post(
         `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
@@ -122,10 +126,13 @@ export default function (data) {
       ),
       { maxRetries: 1, backoffSec: 2, name: '선착순 신청', vu: __VU }
     );
+    const elapsed = Date.now() - start;
+    applyLatency.add(elapsed);
     totalRetries += retries;
 
     if (res.status === 200) {
-      reserveSuccess.add(1);
+      applyOk.add(1);
+      errorRate.add(false);
 
       // Wave 1: 이탈/확정 판단 / Wave 2: 전원 결제확정
       if (!isWave2 && Math.random() < PAYMENT_DROPOUT_RATIO) {
@@ -142,24 +149,24 @@ export default function (data) {
 
       if (confirmRes.status === 200) {
         if (isWave2) {
-          wave2Confirmed.add(1);
+          wave2Ok.add(1);
           resultLog(__VU, `Wave2 결제 확정 (라운드 ${round})`, totalRetries);
         } else {
-          paymentConfirmed.add(1);
-          resultLog(__VU, `결제 확정 (라운드 ${round})`, totalRetries);
+          confirmOk.add(1);
+          resultLog(__VU, `Wave1 결제 확정 (라운드 ${round})`, totalRetries);
         }
       } else {
         unexpectedErr.add(1);
+        errorRate.add(true);
         errorLog(__VU, `결제 확정 실패 (${confirmRes.status}, 라운드 ${round})`);
       }
       break;
 
     } else if (res.status === 409) {
+      applyDup.add(1);
+      errorRate.add(false);
       try {
         const code = res.json().code;
-        if (code === 'ENT_010') {
-          alreadyReserved.add(1);
-        }
         if (round === RETRY_MAX_ROUNDS) {
           soldOut.add(1);
           resultLog(__VU, `최종 매진 (${code})`, totalRetries);
@@ -171,10 +178,73 @@ export default function (data) {
         }
       }
 
+    } else if (res.status === 400) {
+      applyDup.add(1);
+      errorRate.add(false);
+
     } else {
       unexpectedErr.add(1);
+      errorRate.add(true);
       errorLog(__VU, `예상 외 에러 (${res.status}, 라운드 ${round})`);
       break;
     }
   }
+}
+
+// ── teardown: 재고 검증 리포트 ──
+export function teardown(data) {
+  const eventId = data.eventIds.FIRST_COME_NO_QUEUE;
+  const token = data.tokens['1'];
+  if (!token) {
+    console.error('[teardown] 토큰 없음, 검증 스킵');
+    return;
+  }
+
+  const res = http.get(
+    `${BASE_URL}/main/internal/load-test/stock-summary?eventId=${eventId}`,
+    { headers: authHeaders(token), tags: { name: 'stock_summary' } }
+  );
+
+  if (res.status !== 200) {
+    console.error(`[teardown] 재고 검증 API 실패: ${res.status}`);
+    return;
+  }
+
+  const s = res.json().data;
+
+  console.log('');
+  console.log('========================================');
+  console.log('         재고 검증 리포트');
+  console.log('========================================');
+  console.log(`이벤트 ID: ${s.eventId}`);
+  console.log('');
+  console.log(`[DB]    총 재고: ${s.dbTotalStock}  |  확정: ${s.dbConfirmedStock}`);
+  console.log(`[Redis] 잔여:   ${s.redisRemainingStock}  |  확정: ${s.redisConfirmedStock}`);
+  console.log(`[Entry] PRE_SAVED: ${s.entryPreSavedCount}  |  RESERVED: ${s.entryReservedCount}  |  APPLIED: ${s.entryAppliedCount}`);
+  console.log('');
+  console.log(`오버셀링:     ${s.overselling ? '!! 발생 !!' : '없음 (OK)'}`);
+  console.log(`DB-Redis 일치: ${s.dbRedisMatch ? '일치 (OK)' : '!! 불일치 !!'}`);
+  console.log('');
+  console.log('코스/페이스         | DB재고 | DB확정 | R잔여 | R확정 | 일치');
+  console.log('--------------------+--------+--------+-------+-------+-----');
+  for (const p of s.paceDetails) {
+    const label = `${p.courseName}/${p.paceName}`.padEnd(18);
+    const t = String(p.dbTotal).padStart(6);
+    const c = String(p.dbConfirmed).padStart(6);
+    const rr = String(p.redisRemaining).padStart(5);
+    const rc = String(p.redisConfirmed).padStart(5);
+    const m = p.match ? ' OK ' : ' !! ';
+    console.log(`${label} | ${t} | ${c} | ${rr} | ${rc} | ${m}`);
+  }
+  console.log('========================================');
+  console.log('');
+}
+
+// ── handleSummary: 통합 리포트 출력 ──
+export function handleSummary(data) {
+  return buildSummaryOutput(data, {
+    testType: 'LOAD',
+    flow: 'FIRST_COME',
+    vuCount: TOTAL_VUS,
+  });
 }

--- a/backend/k6/scenarios/03-first-come-with-queue.js
+++ b/backend/k6/scenarios/03-first-come-with-queue.js
@@ -10,33 +10,37 @@
 
 import http from 'k6/http';
 import { check, sleep } from 'k6';
-import { Counter, Trend } from 'k6/metrics';
+import { Counter, Rate, Trend } from 'k6/metrics';
 import { batchLoginAll, authHeaders } from '../lib/auth.js';
 import { setupTestData } from '../lib/setup.js';
 import { assignPace } from '../lib/distribution.js';
 import { withRetry } from '../lib/retry.js';
 import { errorLog, resultLog } from '../lib/log.js';
+import { buildSummaryOutput } from '../lib/report.js';
 import {
   BASE_URL, VU_COUNT, EXTRA_VU_COUNT,
   RAMP_UP_SEC, HOLD_SEC, RAMP_DOWN_SEC,
   SETUP_TIMEOUT_SEC,
   QUEUE_POLL_INTERVAL_SEC, QUEUE_MAX_POLL_COUNT,
-  PAYMENT_DROPOUT_RATIO, RETRY_MAX_ROUNDS, RETRY_WAIT_SEC,
+  PAYMENT_DROPOUT_RATIO, RETRY_MAX_ROUNDS, RETRY_WAIT_SEC, RETRY_DELAY_SEC,
 } from '../lib/config.js';
 
 const TOTAL_VUS = VU_COUNT + EXTRA_VU_COUNT;
 
-// 커스텀 메트릭
-const queueWaitTime     = new Trend('queue_wait_time');
-const queuePassCount    = new Counter('queue_pass_count');
-const queueTimeoutCount = new Counter('queue_timeout_count');
-const reserveSuccess    = new Counter('queue_reserve_success');
-const paymentConfirmed  = new Counter('queue_payment_confirmed');
-const paymentDropout    = new Counter('queue_payment_dropout');
-const wave2Confirmed    = new Counter('queue_wave2_confirmed');
-const soldOut           = new Counter('queue_sold_out');
-const alreadyReserved   = new Counter('queue_already_reserved');
-const unexpectedErr     = new Counter('queue_unexpected_error');
+// 커스텀 메트릭 (통일 네이밍)
+const applyOk        = new Counter('apply_ok');
+const applyDup       = new Counter('apply_dup');
+const confirmOk      = new Counter('confirm_ok');
+const paymentDropout = new Counter('payment_dropout');
+const wave2Ok        = new Counter('wave2_ok');
+const soldOut        = new Counter('sold_out');
+const unexpectedErr  = new Counter('unexpected_error');
+const errorRate      = new Rate('error_rate');
+const applyLatency   = new Trend('apply_latency');
+const queueWaitTime  = new Trend('queue_wait_time');
+const blocked        = new Counter('blocked');
+const queuePass      = new Counter('queue_pass');
+const queueTimeout   = new Counter('queue_timeout');
 
 export const options = {
   setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
@@ -118,14 +122,28 @@ export default function (data) {
     () => http.post(
       `${BASE_URL}/queue/enter`,
       JSON.stringify({ paceId }),
-      { headers, tags: { name: 'queue_enter' } }
+      {
+        headers,
+        tags: { name: 'queue_enter' },
+        responseCallback: http.expectedStatuses(200, 409),
+      }
     ),
     { maxRetries: 3, backoffSec: 2, name: '대기열 진입', vu: __VU }
   );
   totalRetries += enterRetries;
 
   check(enterRes, { 'queue enter 200': (r) => r.status === 200 });
+
+  // 409: QUEUE_ALREADY_ENTERED — 비즈니스 차단 (에러 아님)
+  if (enterRes.status === 409) {
+    blocked.add(1);
+    errorRate.add(false);
+    resultLog(__VU, `대기열 진입 차단 — 이미 대기 중 (409)`);
+    return;
+  }
   if (enterRes.status !== 200) {
+    unexpectedErr.add(1);
+    errorRate.add(true);
     errorLog(__VU, `대기열 진입 실패 (${enterRes.status})`);
     return;
   }
@@ -152,7 +170,7 @@ export default function (data) {
           passed = true;
           passToken = body.data.passToken;
           queueWaitTime.add(Date.now() - startWait);
-          queuePassCount.add(1);
+          queuePass.add(1);
           break;
         }
       } catch (e) { /* 다음 폴링 계속 */ }
@@ -160,7 +178,8 @@ export default function (data) {
   }
 
   if (!passed) {
-    queueTimeoutCount.add(1);
+    queueTimeout.add(1);
+    errorRate.add(true);
     errorLog(__VU, `대기열 타임아웃 (${pollCount}회 폴링)`);
     return;
   }
@@ -183,8 +202,9 @@ export default function (data) {
   const applyHeaders = Object.assign({}, headers, { 'X-Queue-Token': passToken });
 
   for (let round = 0; round <= RETRY_MAX_ROUNDS; round++) {
-    if (round > 0) sleep(RETRY_WAIT_SEC);
+    if (round > 0) sleep(RETRY_DELAY_SEC);
 
+    const start = Date.now();
     const { res: applyRes, retries: applyRetries } = withRetry(
       () => http.post(
         `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
@@ -197,16 +217,21 @@ export default function (data) {
       ),
       { maxRetries: 1, backoffSec: 2, name: '선착순 신청', vu: __VU }
     );
+    const elapsed = Date.now() - start;
+    applyLatency.add(elapsed);
     totalRetries += applyRetries;
 
+    // 429: passToken 만료 — 비즈니스 차단 (에러 아님)
     if (applyRes.status === 429) {
-      unexpectedErr.add(1);
-      errorLog(__VU, `passToken 만료 (429, 라운드 ${round})`);
+      blocked.add(1);
+      errorRate.add(false);
+      resultLog(__VU, `passToken 만료 차단 (429, 라운드 ${round})`);
       break;
     }
 
     if (applyRes.status === 200) {
-      reserveSuccess.add(1);
+      applyOk.add(1);
+      errorRate.add(false);
 
       // Wave 1: 이탈/확정 판단 / Wave 2: 전원 결제확정
       if (!isWave2 && Math.random() < PAYMENT_DROPOUT_RATIO) {
@@ -223,24 +248,24 @@ export default function (data) {
 
       if (confirmRes.status === 200) {
         if (isWave2) {
-          wave2Confirmed.add(1);
+          wave2Ok.add(1);
           resultLog(__VU, `Wave2 결제 확정 (라운드 ${round})`, totalRetries);
         } else {
-          paymentConfirmed.add(1);
-          resultLog(__VU, `결제 확정 (라운드 ${round})`, totalRetries);
+          confirmOk.add(1);
+          resultLog(__VU, `Wave1 결제 확정 (라운드 ${round})`, totalRetries);
         }
       } else {
         unexpectedErr.add(1);
+        errorRate.add(true);
         errorLog(__VU, `결제 확정 실패 (${confirmRes.status}, 라운드 ${round})`);
       }
       break;
 
     } else if (applyRes.status === 409) {
+      applyDup.add(1);
+      errorRate.add(false);
       try {
         const code = applyRes.json().code;
-        if (code === 'ENT_010') {
-          alreadyReserved.add(1);
-        }
         if (round === RETRY_MAX_ROUNDS) {
           soldOut.add(1);
           resultLog(__VU, `최종 매진 (${code})`, totalRetries);
@@ -252,10 +277,73 @@ export default function (data) {
         }
       }
 
+    } else if (applyRes.status === 400) {
+      applyDup.add(1);
+      errorRate.add(false);
+
     } else {
       unexpectedErr.add(1);
+      errorRate.add(true);
       errorLog(__VU, `예상 외 에러 (${applyRes.status}, 라운드 ${round})`);
       break;
     }
   }
+}
+
+// ── teardown: 재고 검증 리포트 ──
+export function teardown(data) {
+  const eventId = data.eventIds.FIRST_COME_WITH_QUEUE;
+  const token = data.tokens['1'];
+  if (!token) {
+    console.error('[teardown] 토큰 없음, 검증 스킵');
+    return;
+  }
+
+  const res = http.get(
+    `${BASE_URL}/main/internal/load-test/stock-summary?eventId=${eventId}`,
+    { headers: authHeaders(token), tags: { name: 'stock_summary' } }
+  );
+
+  if (res.status !== 200) {
+    console.error(`[teardown] 재고 검증 API 실패: ${res.status}`);
+    return;
+  }
+
+  const s = res.json().data;
+
+  console.log('');
+  console.log('========================================');
+  console.log('         재고 검증 리포트');
+  console.log('========================================');
+  console.log(`이벤트 ID: ${s.eventId}`);
+  console.log('');
+  console.log(`[DB]    총 재고: ${s.dbTotalStock}  |  확정: ${s.dbConfirmedStock}`);
+  console.log(`[Redis] 잔여:   ${s.redisRemainingStock}  |  확정: ${s.redisConfirmedStock}`);
+  console.log(`[Entry] PRE_SAVED: ${s.entryPreSavedCount}  |  RESERVED: ${s.entryReservedCount}  |  APPLIED: ${s.entryAppliedCount}`);
+  console.log('');
+  console.log(`오버셀링:     ${s.overselling ? '!! 발생 !!' : '없음 (OK)'}`);
+  console.log(`DB-Redis 일치: ${s.dbRedisMatch ? '일치 (OK)' : '!! 불일치 !!'}`);
+  console.log('');
+  console.log('코스/페이스         | DB재고 | DB확정 | R잔여 | R확정 | 일치');
+  console.log('--------------------+--------+--------+-------+-------+-----');
+  for (const p of s.paceDetails) {
+    const label = `${p.courseName}/${p.paceName}`.padEnd(18);
+    const t = String(p.dbTotal).padStart(6);
+    const c = String(p.dbConfirmed).padStart(6);
+    const rr = String(p.redisRemaining).padStart(5);
+    const rc = String(p.redisConfirmed).padStart(5);
+    const m = p.match ? ' OK ' : ' !! ';
+    console.log(`${label} | ${t} | ${c} | ${rr} | ${rc} | ${m}`);
+  }
+  console.log('========================================');
+  console.log('');
+}
+
+// ── handleSummary: 통합 리포트 출력 ──
+export function handleSummary(data) {
+  return buildSummaryOutput(data, {
+    testType: 'LOAD',
+    flow: 'FIRST_COME_QUEUE',
+    vuCount: TOTAL_VUS,
+  });
 }

--- a/backend/k6/scenarios/04-breakpoint.js
+++ b/backend/k6/scenarios/04-breakpoint.js
@@ -1,0 +1,446 @@
+// ========================================================
+// 시나리오 4: 용량(Breakpoint) 테스트
+//
+// 목적: 서버 스펙의 안정 한계를 자동으로 탐지
+// 방식: 계단형 VU 증가 (Staircase) → 한계점 도달 시 자동 중단
+// 흐름: LOTTERY / FIRST_COME / FIRST_COME_QUEUE 선택 가능
+//
+// 실행 예시:
+//   k6 run k6/scenarios/04-breakpoint.js
+//   k6 run -e BP_SCENARIO_FLOW=FIRST_COME -e TOTAL_STOCK=999999 k6/scenarios/04-breakpoint.js
+//   k6 run -e BP_START_VUS=100 -e BP_STEP_VUS=100 -e BP_MAX_VUS=1000 k6/scenarios/04-breakpoint.js
+// ========================================================
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { batchLoginAll, authHeaders } from '../lib/auth.js';
+import { setupTestData } from '../lib/setup.js';
+import { withRetry } from '../lib/retry.js';
+import { errorLog } from '../lib/log.js';
+import { buildSummaryOutput } from '../lib/report.js';
+import {
+  BASE_URL, SETUP_TIMEOUT_SEC,
+  QUEUE_POLL_INTERVAL_SEC, QUEUE_MAX_POLL_COUNT,
+  BP_START_VUS, BP_STEP_VUS, BP_MAX_VUS,
+  BP_STEP_DURATION_SEC, BP_RAMP_SEC,
+  BP_ERROR_THRESHOLD, BP_P95_THRESHOLD_MS,
+  BP_SCENARIO_FLOW, BP_LOGIN_POOL,
+  HOT_PACE_RATIO,
+} from '../lib/config.js';
+import {
+  generateStaircaseStages,
+} from '../lib/breakpoint.js';
+
+// ── 시나리오 타입 매핑 ──
+const FLOW_MAP = {
+  LOTTERY:            'LOTTERY',
+  FIRST_COME:         'FIRST_COME_NO_QUEUE',
+  FIRST_COME_QUEUE:   'FIRST_COME_WITH_QUEUE',
+};
+
+// ── 커스텀 메트릭 (통일 네이밍) ──
+const applyLatency   = new Trend('apply_latency');
+const errorRate      = new Rate('error_rate');
+const applyOk        = new Counter('apply_ok');
+const applyDup       = new Counter('apply_dup');
+const confirmOk      = new Counter('confirm_ok');
+const unexpectedErr  = new Counter('unexpected_error');
+const blocked        = new Counter('blocked');
+const queuePass      = new Counter('queue_pass');
+const queueTimeout   = new Counter('queue_timeout');
+
+// ── 동적 stages 생성 ──
+const stages = generateStaircaseStages(
+  BP_START_VUS, BP_STEP_VUS, BP_MAX_VUS,
+  BP_STEP_DURATION_SEC, BP_RAMP_SEC
+);
+
+export const options = {
+  setupTimeout: `${SETUP_TIMEOUT_SEC}s`,
+  scenarios: {
+    breakpoint: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: stages,
+      gracefulRampDown: '30s',
+      gracefulStop: '30s',
+    },
+  },
+  thresholds: {
+    // 에러율 초과 시 자동 중단
+    error_rate: [{
+      threshold: `rate<${BP_ERROR_THRESHOLD}`,
+      abortOnFail: true,
+      delayAbortEval: '30s',
+    }],
+    // p95 응답시간 초과 시 자동 중단
+    apply_latency: [{
+      threshold: `p(95)<${BP_P95_THRESHOLD_MS}`,
+      abortOnFail: true,
+      delayAbortEval: '30s',
+    }],
+  },
+};
+
+// ================================================================
+// setup: 데이터 셋업 + 일괄 로그인
+// ================================================================
+
+export function setup() {
+  const scenarioType = FLOW_MAP[BP_SCENARIO_FLOW];
+  if (!scenarioType) {
+    throw new Error(`지원하지 않는 BP_SCENARIO_FLOW: ${BP_SCENARIO_FLOW} (LOTTERY / FIRST_COME / FIRST_COME_QUEUE)`);
+  }
+
+  console.log(`[breakpoint] 용량 테스트 시작 — 흐름: ${BP_SCENARIO_FLOW}, VU: ${BP_START_VUS}→${BP_MAX_VUS} (step ${BP_STEP_VUS}), 로그인풀: ${BP_LOGIN_POOL}명, 단계유지: ${BP_STEP_DURATION_SEC}초`);
+
+  // 데이터 셋업
+  const testData = setupTestData(scenarioType);
+
+  // 로그인 풀: BP_MAX_VUS가 아닌 BP_LOGIN_POOL(기본 30,000)명 로그인
+  // 각 VU 반복마다 다른 유저를 사용하여 실제 쓰기(INSERT) 부하 유지
+  const tokens = batchLoginAll(BP_LOGIN_POOL);
+  const loginCount = Object.keys(tokens).length;
+
+  // 페이스 목록 (HOT / 나머지 분리 — 70/30 배분용)
+  const eventKey = Object.keys(testData.eventIds)[0];
+  const eventId = testData.eventIds[eventKey];
+  const paceMapEntry = testData.paceMap[String(eventId)];
+  const hotPaces = paceMapEntry.hot;
+  const otherPaces = paceMapEntry.others;
+  const totalPaceCount = hotPaces.length + otherPaces.length;
+
+  console.log(`[breakpoint] 셋업 완료 — eventId=${eventId}, 로그인풀=${loginCount}명 (동시VU 최대=${BP_MAX_VUS}), 페이스=${totalPaceCount}개`);
+  console.log(`[breakpoint] 페이스 배분 — HOT ${hotPaces.length}개 (VU ${Math.round(HOT_PACE_RATIO * 100)}%), 나머지 ${otherPaces.length}개 (VU ${Math.round((1 - HOT_PACE_RATIO) * 100)}%)`);
+
+  return {
+    tokens,
+    loginCount,
+    eventId,
+    hotPaces,
+    otherPaces,
+    totalPaceCount,
+    flow: BP_SCENARIO_FLOW,
+    testStartMs: Date.now(),
+  };
+}
+
+// ================================================================
+// VU 기본 함수: 연속 반복, 유저 토큰 순환
+// ================================================================
+
+export default function (data) {
+  // 유저 토큰 순환: 각 반복마다 다른 유저 사용 (소수 배수로 골고루 분산)
+  const vuIdx = ((__VU - 1) + __ITER * 7919) % data.loginCount + 1;
+  const token = data.tokens[String(vuIdx)];
+
+  if (!token) {
+    errorRate.add(true);
+    return;
+  }
+
+  const headers = authHeaders(token);
+
+  // 70/30 페이스 배분: VU 번호 기준으로 HOT(70%) / 나머지(30%) 분리
+  const hotCutoff = Math.floor(data.totalPaceCount * HOT_PACE_RATIO);
+  const vuPosition = (__VU - 1) % data.totalPaceCount;
+
+  let pace;
+  if (vuPosition < hotCutoff) {
+    pace = data.hotPaces[vuPosition % data.hotPaces.length];
+  } else {
+    pace = data.otherPaces[(vuPosition - hotCutoff) % data.otherPaces.length];
+  }
+  const { courseId, paceId } = pace;
+  const eventId = data.eventId;
+
+  // 플로우 분기
+  switch (data.flow) {
+    case 'LOTTERY':
+      doLottery(eventId, courseId, paceId, headers);
+      break;
+    case 'FIRST_COME':
+      doFirstCome(eventId, courseId, paceId, headers);
+      break;
+    case 'FIRST_COME_QUEUE':
+      doFirstComeQueue(eventId, courseId, paceId, headers);
+      break;
+  }
+}
+
+// ================================================================
+// 플로우 1: 응모 (LOTTERY)
+// ================================================================
+
+function doLottery(eventId, courseId, paceId, headers) {
+  // 재고 조회
+  http.get(
+    `${BASE_URL}/main/events/${eventId}/entries/stock-check?paceId=${paceId}`,
+    { headers, tags: { name: 'bp_stock_check' } }
+  );
+
+  // 응모 신청
+  const start = Date.now();
+  const res = http.post(
+    `${BASE_URL}/main/events/${eventId}/entries/apply/lottery`,
+    JSON.stringify({ courseId, paceId }),
+    {
+      headers,
+      tags: { name: 'bp_apply' },
+      responseCallback: http.expectedStatuses(200, 400, 409),
+    }
+  );
+  const elapsed = Date.now() - start;
+
+  applyLatency.add(elapsed);
+  recordResult(res);
+}
+
+// ================================================================
+// 플로우 2: 선착순 대기열X (FIRST_COME)
+// ================================================================
+
+function doFirstCome(eventId, courseId, paceId, headers) {
+  // 재고 조회
+  http.get(
+    `${BASE_URL}/main/events/${eventId}/entries/stock-check?paceId=${paceId}`,
+    { headers, tags: { name: 'bp_stock_check' } }
+  );
+
+  // 선착순 신청
+  const start = Date.now();
+  const res = http.post(
+    `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
+    JSON.stringify({ courseId, paceId }),
+    {
+      headers,
+      tags: { name: 'bp_apply' },
+      responseCallback: http.expectedStatuses(200, 400, 409),
+    }
+  );
+  const elapsed = Date.now() - start;
+
+  applyLatency.add(elapsed);
+
+  if (res.status === 200) {
+    applyOk.add(1);
+    errorRate.add(false);
+
+    // 결제 확정
+    const confirmRes = http.post(
+      `${BASE_URL}/main/internal/load-test/confirm-reservation`,
+      JSON.stringify({ paceId }),
+      { headers, tags: { name: 'bp_confirm' } }
+    );
+
+    if (confirmRes.status === 200) {
+      confirmOk.add(1);
+    }
+  } else if (res.status === 409 || res.status === 400) {
+    applyDup.add(1);
+    errorRate.add(false);
+  } else {
+    unexpectedErr.add(1);
+    errorRate.add(true);
+    errorLog(__VU, `선착순 신청 실패 (${res.status})`);
+  }
+}
+
+// ================================================================
+// 플로우 3: 선착순 대기열O (FIRST_COME_QUEUE)
+// ================================================================
+
+function doFirstComeQueue(eventId, courseId, paceId, headers) {
+  // 대기열 진입
+  const { res: enterRes } = withRetry(
+    () => http.post(
+      `${BASE_URL}/queue/enter`,
+      JSON.stringify({ paceId }),
+      {
+        headers,
+        tags: { name: 'bp_queue_enter' },
+        responseCallback: http.expectedStatuses(200, 409),
+      }
+    ),
+    { maxRetries: 2, backoffSec: 2, name: '대기열 진입', vu: __VU }
+  );
+
+  // 409: QUEUE_ALREADY_ENTERED — 비즈니스 차단 (에러 아님)
+  if (enterRes.status === 409) {
+    blocked.add(1);
+    errorRate.add(false);
+    return;
+  }
+  if (enterRes.status !== 200) {
+    unexpectedErr.add(1);
+    errorRate.add(true);
+    errorLog(__VU, `대기열 진입 실패 (${enterRes.status})`);
+    return;
+  }
+
+  // 대기열 폴링 (PASS까지)
+  let passed = false;
+  let passToken = null;
+
+  for (let i = 0; i < QUEUE_MAX_POLL_COUNT; i++) {
+    sleep(QUEUE_POLL_INTERVAL_SEC);
+
+    const statusRes = http.get(
+      `${BASE_URL}/queue/status?paceId=${paceId}`,
+      { headers, tags: { name: 'bp_queue_poll' } }
+    );
+
+    if (statusRes.status === 200) {
+      try {
+        const body = statusRes.json();
+        if (body.data && body.data.status === 'PASS') {
+          passed = true;
+          passToken = body.data.passToken;
+          queuePass.add(1);
+          break;
+        }
+      } catch (_) { /* 다음 폴링 계속 */ }
+    }
+  }
+
+  if (!passed) {
+    queueTimeout.add(1);
+    errorRate.add(true);
+    errorLog(__VU, '대기열 타임아웃');
+    return;
+  }
+
+  // 선착순 신청 (passToken 포함)
+  const applyHeaders = Object.assign({}, headers, { 'X-Queue-Token': passToken });
+  const start = Date.now();
+  const applyRes = http.post(
+    `${BASE_URL}/main/events/${eventId}/entries/apply/first-come`,
+    JSON.stringify({ courseId, paceId }),
+    {
+      headers: applyHeaders,
+      tags: { name: 'bp_apply' },
+      responseCallback: http.expectedStatuses(200, 400, 409, 429),
+    }
+  );
+  const elapsed = Date.now() - start;
+
+  applyLatency.add(elapsed);
+
+  if (applyRes.status === 200) {
+    applyOk.add(1);
+    errorRate.add(false);
+
+    // 결제 확정
+    const confirmRes = http.post(
+      `${BASE_URL}/main/internal/load-test/confirm-reservation`,
+      JSON.stringify({ paceId }),
+      { headers, tags: { name: 'bp_confirm' } }
+    );
+    if (confirmRes.status === 200) {
+      confirmOk.add(1);
+    }
+  } else if (applyRes.status === 429) {
+    // passToken 만료 — 비즈니스 차단 (에러 아님)
+    blocked.add(1);
+    errorRate.add(false);
+  } else if (applyRes.status === 409 || applyRes.status === 400) {
+    applyDup.add(1);
+    errorRate.add(false);
+  } else {
+    unexpectedErr.add(1);
+    errorRate.add(true);
+    errorLog(__VU, `선착순 신청 실패 (${applyRes.status})`);
+  }
+}
+
+// ================================================================
+// 공통: 결과 기록 (LOTTERY용)
+// ================================================================
+
+function recordResult(res) {
+  if (res.status === 200) {
+    applyOk.add(1);
+    errorRate.add(false);
+  } else if (res.status === 400 || res.status === 409) {
+    applyDup.add(1);
+    errorRate.add(false);
+  } else {
+    unexpectedErr.add(1);
+    errorRate.add(true);
+    errorLog(__VU, `응모 실패 (${res.status})`);
+  }
+}
+
+// ================================================================
+// teardown: 재고 검증 리포트 (FIRST_COME / FIRST_COME_QUEUE만)
+// ================================================================
+
+export function teardown(data) {
+  // LOTTERY는 재고 소진 개념이 없으므로 스킵
+  if (data.flow === 'LOTTERY') return;
+
+  const token = data.tokens['1'];
+  if (!token) {
+    console.error('[teardown] 토큰 없음, 검증 스킵');
+    return;
+  }
+
+  const res = http.get(
+    `${BASE_URL}/main/internal/load-test/stock-summary?eventId=${data.eventId}`,
+    { headers: authHeaders(token), tags: { name: 'stock_summary' } }
+  );
+
+  if (res.status !== 200) {
+    console.error(`[teardown] 재고 검증 API 실패: ${res.status}`);
+    return;
+  }
+
+  const s = res.json().data;
+
+  console.log('');
+  console.log('========================================');
+  console.log('         재고 검증 리포트');
+  console.log('========================================');
+  console.log(`이벤트 ID: ${s.eventId}`);
+  console.log('');
+  console.log(`[DB]    총 재고: ${s.dbTotalStock}  |  확정: ${s.dbConfirmedStock}`);
+  console.log(`[Redis] 잔여:   ${s.redisRemainingStock}  |  확정: ${s.redisConfirmedStock}`);
+  console.log(`[Entry] PRE_SAVED: ${s.entryPreSavedCount}  |  RESERVED: ${s.entryReservedCount}  |  APPLIED: ${s.entryAppliedCount}`);
+  console.log('');
+  console.log(`오버셀링:     ${s.overselling ? '!! 발생 !!' : '없음 (OK)'}`);
+  console.log(`DB-Redis 일치: ${s.dbRedisMatch ? '일치 (OK)' : '!! 불일치 !!'}`);
+  console.log('');
+  console.log('코스/페이스         | DB재고 | DB확정 | R잔여 | R확정 | 일치');
+  console.log('--------------------+--------+--------+-------+-------+-----');
+  for (const p of s.paceDetails) {
+    const label = `${p.courseName}/${p.paceName}`.padEnd(18);
+    const t = String(p.dbTotal).padStart(6);
+    const c = String(p.dbConfirmed).padStart(6);
+    const rr = String(p.redisRemaining).padStart(5);
+    const rc = String(p.redisConfirmed).padStart(5);
+    const m = p.match ? ' OK ' : ' !! ';
+    console.log(`${label} | ${t} | ${c} | ${rr} | ${rc} | ${m}`);
+  }
+  console.log('========================================');
+  console.log('');
+}
+
+// ================================================================
+// handleSummary: 통합 리포트 출력
+// ================================================================
+
+export function handleSummary(data) {
+  return buildSummaryOutput(data, {
+    testType: 'BREAKPOINT',
+    flow: BP_SCENARIO_FLOW,
+    startVUs: BP_START_VUS,
+    stepVUs: BP_STEP_VUS,
+    maxVUs: BP_MAX_VUS,
+    stepDurationSec: BP_STEP_DURATION_SEC,
+    rampSec: BP_RAMP_SEC,
+    errorThreshold: BP_ERROR_THRESHOLD,
+    p95ThresholdMs: BP_P95_THRESHOLD_MS,
+    loginPool: BP_LOGIN_POOL,
+  });
+}

--- a/backend/k6/scenarios/04-breakpoint.js
+++ b/backend/k6/scenarios/04-breakpoint.js
@@ -16,6 +16,7 @@ import { check, sleep } from 'k6';
 import { Trend, Rate, Counter } from 'k6/metrics';
 import { batchLoginAll, authHeaders } from '../lib/auth.js';
 import { setupTestData } from '../lib/setup.js';
+import { assignPace } from '../lib/distribution.js';
 import { withRetry } from '../lib/retry.js';
 import { errorLog } from '../lib/log.js';
 import { buildSummaryOutput } from '../lib/report.js';
@@ -26,7 +27,6 @@ import {
   BP_STEP_DURATION_SEC, BP_RAMP_SEC,
   BP_ERROR_THRESHOLD, BP_P95_THRESHOLD_MS,
   BP_SCENARIO_FLOW, BP_LOGIN_POOL,
-  HOT_PACE_RATIO,
 } from '../lib/config.js';
 import {
   generateStaircaseStages,
@@ -118,9 +118,7 @@ export function setup() {
     tokens,
     loginCount,
     eventId,
-    hotPaces,
-    otherPaces,
-    totalPaceCount,
+    paceMapEntry: { hot: hotPaces, others: otherPaces },
     flow: BP_SCENARIO_FLOW,
     testStartMs: Date.now(),
   };
@@ -142,17 +140,8 @@ export default function (data) {
 
   const headers = authHeaders(token);
 
-  // 70/30 페이스 배분: VU 번호 기준으로 HOT(70%) / 나머지(30%) 분리
-  const hotCutoff = Math.floor(data.totalPaceCount * HOT_PACE_RATIO);
-  const vuPosition = (__VU - 1) % data.totalPaceCount;
-
-  let pace;
-  if (vuPosition < hotCutoff) {
-    pace = data.hotPaces[vuPosition % data.hotPaces.length];
-  } else {
-    pace = data.otherPaces[(vuPosition - hotCutoff) % data.otherPaces.length];
-  }
-  const { courseId, paceId } = pace;
+  // 70/30 페이스 배분: assignPace 공통 로직 사용 (10-VU 블록 인터리브)
+  const { courseId, paceId } = assignPace(__VU, data.paceMapEntry);
   const eventId = data.eventId;
 
   // 플로우 분기

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryContractService.java
@@ -71,7 +71,7 @@ public class EntryContractService implements OrderEntryContract {
 		if (!shouldRollback) return;
 
 		Long paceId = entry.getEventPace().getId();
-		eventStockRepository.findByEventPaceIdOrThrow(paceId).cancelStock();
+		eventStockRepository.decrementConfirmedStock(paceId);
 
 		if (appType == EventAppType.FIRST_COME) {
 			eventStockService.cancelTempStock(paceId);

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -284,7 +284,7 @@ public class EntryService {
 			entry.confirmPayment();
 		}
 
-		eventStockRepository.findByEventPaceIdOrThrow(paceId).confirmStock();
+		eventStockRepository.incrementConfirmedStock(paceId);
 
 		log.info("[ENTRY] 결제 확정 userId={}, paceId={}, appType={}", userId, paceId, type);
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/repository/EventStockRepository.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/repository/EventStockRepository.java
@@ -8,7 +8,7 @@ import com.kt.onrace.common.exception.BusinessErrorCode;
 import com.kt.onrace.common.exception.BusinessException;
 import com.kt.onrace.domain.event.entity.EventStock;
 
-public interface EventStockRepository extends JpaRepository<EventStock, Long> {
+public interface EventStockRepository extends JpaRepository<EventStock, Long>, EventStockRepositoryCustom {
 
 	Optional<EventStock> findByEventPaceId(Long eventPaceId);
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/repository/EventStockRepositoryCustom.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/repository/EventStockRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.kt.onrace.domain.event.repository;
+
+public interface EventStockRepositoryCustom {
+
+	int incrementConfirmedStock(Long paceId);
+	int decrementConfirmedStock(Long paceId);
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/repository/EventStockRepositoryImpl.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/repository/EventStockRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.kt.onrace.domain.event.repository;
+
+import static com.kt.onrace.domain.event.entity.QEventStock.*;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class EventStockRepositoryImpl implements EventStockRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public int incrementConfirmedStock(Long paceId) {
+		return (int)queryFactory
+			.update(eventStock)
+			.set(eventStock.confirmedStock, eventStock.confirmedStock.add(1))
+			.set(eventStock.version, eventStock.version.add(1L))
+			.where(eventStock.eventPace.id.eq(paceId))
+			.execute();
+	}
+
+	@Override
+	public int decrementConfirmedStock(Long paceId) {
+		return (int)queryFactory
+			.update(eventStock)
+			.set(eventStock.confirmedStock, eventStock.confirmedStock.subtract(1))
+			.set(eventStock.version, eventStock.version.add(1L))
+			.where(eventStock.eventPace.id.eq(paceId))
+			.execute();
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/controller/LoadTestController.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/controller/LoadTestController.java
@@ -1,9 +1,11 @@
 package com.kt.onrace.domain.loadtest.controller;
 
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.onrace.common.logging.annotation.ApiLog;
@@ -11,6 +13,7 @@ import com.kt.onrace.common.response.ApiResponse;
 import com.kt.onrace.domain.loadtest.dto.LoadTestConfirmRequest;
 import com.kt.onrace.domain.loadtest.dto.LoadTestSetupRequest;
 import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse;
+import com.kt.onrace.domain.loadtest.dto.LoadTestStockSummaryResponse;
 import com.kt.onrace.domain.loadtest.service.LoadTestService;
 
 import jakarta.validation.Valid;
@@ -45,8 +48,7 @@ public class LoadTestController {
 
 	/**
 	 * 테스트 전용 예약 확정 (Toss 결제 우회)
-	 * EntryService.confirmReservation()을 직접 호출하여
-	 * RESERVED → APPLIED 상태 전환 + 재고 확정 처리
+	 * JDBC Atomic UPDATE로 RESERVED → APPLIED 상태 전환 + 재고 확정 처리
 	 */
 	@PostMapping("/confirm-reservation")
 	public ApiResponse<Void> confirmReservation(
@@ -55,5 +57,16 @@ public class LoadTestController {
 	) {
 		loadTestService.confirmReservation(userId, request.paceId());
 		return ApiResponse.success(null);
+	}
+
+	/**
+	 * 재고 검증 리포트 (DB vs Redis 비교)
+	 * teardown 단계에서 호출하여 오버셀링/데이터 정합성 검증
+	 */
+	@GetMapping("/stock-summary")
+	public ApiResponse<LoadTestStockSummaryResponse> getStockSummary(
+		@RequestParam Long eventId
+	) {
+		return ApiResponse.success(loadTestService.getStockSummary(eventId));
 	}
 }

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestStockSummaryResponse.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/dto/LoadTestStockSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.kt.onrace.domain.loadtest.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record LoadTestStockSummaryResponse(
+	long eventId,
+	int dbTotalStock,
+	int dbConfirmedStock,
+	long redisRemainingStock,
+	long redisConfirmedStock,
+	int entryReservedCount,
+	int entryAppliedCount,
+	int entryPreSavedCount,
+	boolean overselling,
+	boolean dbRedisMatch,
+	List<PaceDetail> paceDetails
+) {
+
+	@Builder
+	public record PaceDetail(
+		long paceId,
+		String courseName,
+		String paceName,
+		int dbTotal,
+		int dbConfirmed,
+		long redisRemaining,
+		long redisConfirmed,
+		boolean match
+	) {
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/loadtest/service/LoadTestService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/loadtest/service/LoadTestService.java
@@ -23,6 +23,8 @@ import com.kt.onrace.domain.event.service.EventService;
 import com.kt.onrace.domain.event.service.EventStockInitializer;
 import com.kt.onrace.domain.loadtest.dto.LoadTestSetupRequest;
 import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse;
+import com.kt.onrace.domain.loadtest.dto.LoadTestStockSummaryResponse;
+import com.kt.onrace.domain.loadtest.dto.LoadTestStockSummaryResponse.PaceDetail;
 import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse.PaceMapEntry;
 import com.kt.onrace.domain.loadtest.dto.LoadTestSetupResponse.PaceRef;
 
@@ -44,7 +46,6 @@ public class LoadTestService {
 	private final EventStockInitializer eventStockInitializer;
 	private final EventService eventService;
 	private final EntryService entryService;
-
 	private static final int TOTAL_USERS = 30000;
 	private static final int TOTAL_PACES = 15; // 코스 3개 x 페이스 5개
 	private static final String BCRYPT_HASH = "$2a$10$HWNLFZOjTELM0EaGC14xCeXLBC4RhgmlctVcED4/8MCM8KQ9y4xQS";
@@ -165,12 +166,91 @@ public class LoadTestService {
 	}
 
 	// ================================================================
-	// 테스트 전용 예약 확정 (Toss 결제 우회)
+	// 테스트 전용 예약 확정 (Toss 결제 우회 — 프로덕션 코드 직접 호출)
 	// ================================================================
 
-	@Transactional
 	public void confirmReservation(Long userId, Long paceId) {
 		entryService.confirmReservation(userId, paceId, EventAppType.FIRST_COME);
+	}
+
+	// ================================================================
+	// 재고 검증 리포트 (DB vs Redis 비교)
+	// ================================================================
+
+	@Transactional(readOnly = true)
+	public LoadTestStockSummaryResponse getStockSummary(Long eventId) {
+		// 1. DB: 페이스별 재고 조회
+		List<Map<String, Object>> rows = jdbcTemplate.queryForList("""
+			SELECT ep.id AS pace_id, ep.name AS pace_name, ec.name AS course_name,
+			       es.total_stock, es.confirmed_stock
+			FROM event_pace ep
+			JOIN event_course ec ON ep.course_id = ec.id
+			JOIN event_stock es ON es.event_pace_id = ep.id
+			WHERE ec.event_id = ?
+			ORDER BY ec.id, ep.id
+			""", eventId);
+
+		int dbTotalStock = 0;
+		int dbConfirmedStock = 0;
+		long redisRemainingTotal = 0;
+		long redisConfirmedTotal = 0;
+		boolean allMatch = true;
+		boolean overselling = false;
+
+		List<PaceDetail> paceDetails = new ArrayList<>();
+
+		for (Map<String, Object> row : rows) {
+			long paceId = ((Number)row.get("pace_id")).longValue();
+			int dbTotal = ((Number)row.get("total_stock")).intValue();
+			int dbConfirmed = ((Number)row.get("confirmed_stock")).intValue();
+
+			long redisRemaining = redissonClient.getAtomicLong("stock:temp:pace:" + paceId).get();
+			long redisConfirmed = redissonClient.getAtomicLong("stock:confirm:pace:" + paceId).get();
+
+			boolean match = dbConfirmed == (int)redisConfirmed;
+			if (!match) allMatch = false;
+			if (dbConfirmed > dbTotal) overselling = true;
+
+			dbTotalStock += dbTotal;
+			dbConfirmedStock += dbConfirmed;
+			redisRemainingTotal += redisRemaining;
+			redisConfirmedTotal += redisConfirmed;
+
+			paceDetails.add(PaceDetail.builder()
+				.paceId(paceId)
+				.courseName((String)row.get("course_name"))
+				.paceName((String)row.get("pace_name"))
+				.dbTotal(dbTotal)
+				.dbConfirmed(dbConfirmed)
+				.redisRemaining(redisRemaining)
+				.redisConfirmed(redisConfirmed)
+				.match(match)
+				.build());
+		}
+
+		// 2. Entry 상태별 카운트
+		Map<String, Integer> entryCounts = new LinkedHashMap<>();
+		jdbcTemplate.queryForList(
+			"SELECT status, COUNT(*) AS cnt FROM entry WHERE event_id = ? GROUP BY status",
+			eventId
+		).forEach(r -> entryCounts.put(
+			(String)r.get("status"),
+			((Number)r.get("cnt")).intValue()
+		));
+
+		return LoadTestStockSummaryResponse.builder()
+			.eventId(eventId)
+			.dbTotalStock(dbTotalStock)
+			.dbConfirmedStock(dbConfirmedStock)
+			.redisRemainingStock(redisRemainingTotal)
+			.redisConfirmedStock(redisConfirmedTotal)
+			.entryReservedCount(entryCounts.getOrDefault("RESERVED", 0))
+			.entryAppliedCount(entryCounts.getOrDefault("APPLIED", 0))
+			.entryPreSavedCount(entryCounts.getOrDefault("PRE_SAVED", 0))
+			.overselling(overselling)
+			.dbRedisMatch(allMatch)
+			.paceDetails(paceDetails)
+			.build();
 	}
 
 	// ================================================================


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
k6 테스트
- 전 시나리오(01~04) 커스텀 메트릭 네이밍 템플릿과 연동
- 비즈니스 차단 제외
- VU 배분을 범위 기반 변경하여 Wave 2 VU도 70/30 비율 보장
- 균등 배분 → 70/30 HOT 집중 배분
- 선착순 시나리오(02~04) teardown에서 DB vs Redis 재고 정합성 리포트 출력
-  기존 지정 테스트 외 한계 테스트 추가

동시성 이슈
- GET /internal/load-test/stock-summary 엔드포인트 추가
- 재고 확정을 엔티티 메서드 대신 JDBC Atomic UPDATE로 변경
- 결제 취소도 동일하게 Atomic UPDATE 적용

## 📸 스크린샷 / 아키텍처 / 로그 (필수)

- UI 변경 시 스크린샷 첨부 (Frontend 필수)
- 로직 변경 시 관련 로그나 다이어그램, 테스트 결과 캡처 첨부 (Backend/Infra 필수)
- _멘토링 피드백: "글보다 그림/화면으로 소통하세요"_

## ❓ 변경 이유 (Why)
- 시나리오별 메트릭 이름이 다르면(`lottery_apply_success`, `queue_reserve_success` 등) 통합 리포트에서 일관된 분석이 불가
- 비즈니스 차단(409/429)이 서버 에러와 구분되지 않아 에러율이 과대 집계됨
- Wave 2 VU가 전원 Others로 배분되어 HOT 페이스 이탈 재고(~7석)를 회수하지 못해 매진 미달 발생
- teardown 재고 검증 없이는 오버셀링/데이터 정합성 확인이 불가

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
