### PR TITLE
feat: 대기열 폴링 jitter 방식 적용

### DIFF
--- a/backend/k6/lib/report.js
+++ b/backend/k6/lib/report.js
@@ -192,8 +192,9 @@ function formatBusinessMetrics(data, flow) {
   const queuePassCount = counter(m, 'queue_pass');
   const queueTimeoutCt = counter(m, 'queue_timeout');
   // 세분화된 차단 카운터 (FIRST_COME_QUEUE 전용)
-  const blockedQueueDup     = counter(m, 'blocked_queue_dup');     // 409 — 대기열 이미 진입
-  const blockedTokenExpired = counter(m, 'blocked_token_expired'); // 429 — passToken 만료
+  const blockedQueueDup          = counter(m, 'blocked_queue_dup');          // 409 — 대기열 이미 진입
+  const blockedTokenExpired      = counter(m, 'blocked_token_expired');      // 429 — passToken 만료
+  const blockedReservationExpired = counter(m, 'blocked_reservation_expired'); // 400 ENT_009 — 예약 TTL 만료
 
   const totalApply = applyOk + applyDup;
 
@@ -247,6 +248,10 @@ function formatBusinessMetrics(data, flow) {
     lines.push(`  선착순 차단:     ${fmt(blockedTokenExpired)}건 (passToken 만료 429)`);
   } else {
     lines.push(`  비즈니스 차단:  ${fmt(blockedCount)}건`);
+  }
+  // 예약 TTL 만료 차단 (FIRST_COME / FIRST_COME_QUEUE 공통)
+  if (flow === 'FIRST_COME' || flow === 'FIRST_COME_QUEUE') {
+    lines.push(`  예약 만료 차단:  ${fmt(blockedReservationExpired)}건 (TTL 초과 400)`);
   }
   lines.push(`  서버 에러:      ${fmt(unexpectedErr)}건`);
 

--- a/backend/k6/scenarios/02-first-come-no-queue.js
+++ b/backend/k6/scenarios/02-first-come-no-queue.js
@@ -34,7 +34,8 @@ const confirmOk        = new Counter('confirm_ok');
 const paymentDropout   = new Counter('payment_dropout');
 const wave2Ok          = new Counter('wave2_ok');
 const soldOut          = new Counter('sold_out');
-const unexpectedErr    = new Counter('unexpected_error');
+const unexpectedErr             = new Counter('unexpected_error');
+const blockedReservationExpired = new Counter('blocked_reservation_expired'); // 400 ENT_009: 예약 TTL 만료
 const errorRate        = new Rate('error_rate');
 const applyLatency     = new Trend('apply_latency');
 // 병목(hold) 구간 응답시간: active VU가 target의 95% 이상일 때만 기록
@@ -169,6 +170,11 @@ export default function (data) {
           confirmOk.add(1);
           resultLog(__VU, `Wave1 결제 확정 (라운드 ${round})`, totalRetries);
         }
+      } else if (confirmRes.status === 400) {
+        // ENT_009: 예약 TTL 만료 / ENT_007: 신청 불가 상태 — 비즈니스 차단 (에러 아님)
+        blockedReservationExpired.add(1);
+        errorRate.add(false);
+        resultLog(__VU, `예약 만료 차단 (${confirmRes.status}, 라운드 ${round})`);
       } else {
         unexpectedErr.add(1);
         errorRate.add(true);

--- a/backend/k6/scenarios/03-first-come-with-queue.js
+++ b/backend/k6/scenarios/03-first-come-with-queue.js
@@ -45,8 +45,9 @@ const queueWaitTime    = new Trend('queue_wait_time');
 // 병목 판정 임계값 (TOTAL_VUS의 95%)
 const PEAK_VU_THRESHOLD = Math.max(1, Math.floor(TOTAL_VUS * 0.95));
 // 비즈니스 차단 카운터를 원인별로 분리 — 리포트에서 원인 분석 가능하도록 함
-const blockedQueueDup     = new Counter('blocked_queue_dup');     // 409: 대기열 이미 진입 중
-const blockedTokenExpired = new Counter('blocked_token_expired'); // 429: passToken 만료
+const blockedQueueDup          = new Counter('blocked_queue_dup');          // 409: 대기열 이미 진입 중
+const blockedTokenExpired      = new Counter('blocked_token_expired');      // 429: passToken 만료
+const blockedReservationExpired = new Counter('blocked_reservation_expired'); // 400 ENT_009: 예약 TTL 만료
 const queuePass      = new Counter('queue_pass');
 const queueTimeout   = new Counter('queue_timeout');
 // 재고 검증 결과를 teardown에서 기록하여 통합 리포트에 포함시키기 위한 Gauge
@@ -277,6 +278,11 @@ export default function (data) {
           confirmOk.add(1);
           resultLog(__VU, `Wave1 결제 확정 (라운드 ${round})`, totalRetries);
         }
+      } else if (confirmRes.status === 400) {
+        // ENT_009: 예약 TTL 만료 / ENT_007: 신청 불가 상태 — 비즈니스 차단 (에러 아님)
+        blockedReservationExpired.add(1);
+        errorRate.add(false);
+        resultLog(__VU, `예약 만료 차단 (${confirmRes.status}, 라운드 ${round})`);
       } else {
         unexpectedErr.add(1);
         errorRate.add(true);

--- a/backend/k6/scenarios/03-first-come-with-queue.js
+++ b/backend/k6/scenarios/03-first-come-with-queue.js
@@ -167,9 +167,11 @@ export default function (data) {
   let passToken = null;
   let pollCount = 0;
 
+  // 서버 응답의 retryAfterMs 사용, 없으면 기존 클라이언트 jitter 폴백
+  let retryAfterSec = QUEUE_POLL_INTERVAL_SEC * (0.8 + Math.random() * 0.4);
+
   for (let i = 0; i < QUEUE_MAX_POLL_COUNT; i++) {
-    // ±20% jitter: 폴링 동시 집중(micro-burst) 방지
-    sleep(QUEUE_POLL_INTERVAL_SEC * (0.8 + Math.random() * 0.4));
+    sleep(retryAfterSec);
     pollCount++;
 
     const statusRes = http.get(
@@ -186,6 +188,10 @@ export default function (data) {
           queueWaitTime.add(Date.now() - startWait);
           queuePass.add(1);
           break;
+        }
+        // 서버가 retryAfterMs를 내려주면 사용, 아니면 클라이언트 jitter 유지
+        if (body.data && body.data.retryAfterMs) {
+          retryAfterSec = body.data.retryAfterMs / 1000;
         }
       } catch (e) { /* 다음 폴링 계속 */ }
     }

--- a/backend/queue/src/main/java/com/kt/onrace/queue/config/QueueProperties.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/config/QueueProperties.java
@@ -13,4 +13,6 @@ public class QueueProperties {
 	private final long intervalMs;
 	private final long passTtlSeconds;
 	private final String tokenSecret;
+	private final long pollBaseMs;
+	private final long pollJitterMs;
 }

--- a/backend/queue/src/main/java/com/kt/onrace/queue/dto/QueueStatusResponse.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/dto/QueueStatusResponse.java
@@ -7,13 +7,15 @@ public record QueueStatusResponse(
 	Long paceId,
 	String status,
 	Long position,
-	String passToken
+	String passToken,
+	Long retryAfterMs // 인프라 요청사항 - 폴링 지터 적용
 ) {
-	public static QueueStatusResponse waiting(Long paceId, Long position) {
+	public static QueueStatusResponse waiting(Long paceId, Long position, Long retryAfterMs) {
 		return QueueStatusResponse.builder()
 			.paceId(paceId)
 			.status("WAITING")
 			.position(position)
+			.retryAfterMs(retryAfterMs)
 			.build();
 	}
 

--- a/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
@@ -1,5 +1,7 @@
 package com.kt.onrace.queue.service;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 import org.redisson.api.RBucket;
 import org.redisson.api.RScoredSortedSet;
 import org.redisson.api.RSet;
@@ -13,6 +15,7 @@ import com.kt.onrace.common.logging.annotation.ServiceLog;
 import com.kt.onrace.common.util.Preconditions;
 import com.kt.onrace.common.util.RedisKeyGenerator;
 import com.kt.onrace.queue.config.QueueMetrics;
+import com.kt.onrace.queue.config.QueueProperties;
 import com.kt.onrace.queue.dto.QueueEnterResponse;
 import com.kt.onrace.queue.dto.QueueStatusResponse;
 
@@ -25,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class QueueService {
 	private final RedissonClient redissonClient;
 	private final QueueMetrics queueMetrics;
+	private final QueueProperties queueProperties;
 
 	@ServiceLog
 	public QueueEnterResponse enter(Long userId, Long paceId) {
@@ -69,8 +73,11 @@ public class QueueService {
 		Integer rank = waitingSet.rank(String.valueOf(userId));
 
 		if (rank != null) {
-			log.debug("[QUEUE] 대기 중 userId={}, paceId={}, position={}", userId, paceId, rank + 1);
-			return QueueStatusResponse.waiting(paceId, (long) rank + 1);
+			long position = rank + 1;
+			long retryAfterMs = queueProperties.getPollBaseMs()
+				+ ThreadLocalRandom.current().nextLong(queueProperties.getPollJitterMs());
+			log.debug("[QUEUE] 대기 중 userId={}, paceId={}, position={}", userId, paceId, position);
+			return QueueStatusResponse.waiting(paceId, position, retryAfterMs);
 		}
 
 		throw new BusinessException(BusinessErrorCode.QUEUE_NOT_FOUND);

--- a/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
@@ -74,8 +74,9 @@ public class QueueService {
 
 		if (rank != null) {
 			long position = rank + 1;
+			long jitterMs = queueProperties.getPollJitterMs();
 			long retryAfterMs = queueProperties.getPollBaseMs()
-				+ ThreadLocalRandom.current().nextLong(queueProperties.getPollJitterMs());
+				+ (jitterMs > 0 ? ThreadLocalRandom.current().nextLong(jitterMs) : 0);
 			log.debug("[QUEUE] 대기 중 userId={}, paceId={}, position={}", userId, paceId, position);
 			return QueueStatusResponse.waiting(paceId, position, retryAfterMs);
 		}

--- a/backend/queue/src/main/resources/application.yml
+++ b/backend/queue/src/main/resources/application.yml
@@ -35,6 +35,8 @@ queue:
   interval-ms: ${QUEUE_INTERVAL_MS:3000}
   pass-ttl-seconds: ${QUEUE_PASS_TTL_SECONDS:600}
   token-secret: ${QUEUE_TOKEN_SECRET}
+  poll-base-ms: ${QUEUE_POLL_BASE_MS:3000}
+  poll-jitter-ms: ${QUEUE_POLL_JITTER_MS:2000}
 
 management:
   endpoints:


### PR DESCRIPTION
- 인프라 요청사항
- 대기열 폴링 시 간격을 두고 요청함으로써 부하 방지

## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
- 인프라 요청사항
- 대기열 폴링 시 간격을 두고 요청함으로써 부하 방지

## 📸 스크린샷 / 아키텍처 / 로그 (필수)
대기열 입장 -> 순서 조회(폴링 시 일정 간격이 아닌 지터 방식 사용) -> 대기열 통과

## ❓ 변경 이유 (Why)
- 대기열 폴링 시 간격을 두고 요청함으로써 부하 방지

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
