### PR TITLE
서버 포트 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,10 @@ RUN apk add --no-cache tzdata && \
     cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
     echo "Asia/Seoul" > /etc/timezone
 
+ENV AWS_EC2_METADATA_DISABLED=true \
+    AWS_METADATA_SERVICE_TIMEOUT=1
+
 COPY --from=builder /workspace/app.jar app.jar
 
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Daws.disableEc2Metadata=true", "-Daws.disableEc2MetadataV1=true", "-Daws.ec2MetadataServiceTimeout=1", "-Dcom.amazonaws.sdk.disableEc2Metadata=true", "-jar", "app.jar"]

--- a/backend/common/build.gradle
+++ b/backend/common/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     api 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.7'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 bootJar {

--- a/backend/common/build.gradle
+++ b/backend/common/build.gradle
@@ -13,7 +13,9 @@ dependencies {
     
     // S3
     api platform("software.amazon.awssdk:bom:2.31.66")
+    api "software.amazon.awssdk:apache-client"
     api "software.amazon.awssdk:s3"
+    api "software.amazon.awssdk:sts"
 
     // OPENAPI/SWAGGER
     api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/backend/common/src/main/java/com/kt/onrace/common/config/S3Config.java
+++ b/backend/common/src/main/java/com/kt/onrace/common/config/S3Config.java
@@ -1,33 +1,160 @@
 package com.kt.onrace.common.config;
 
+import java.nio.file.Path;
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsWebIdentityTokenFileCredentialsProvider;
 
+@Slf4j
 @Configuration
 @ConditionalOnClass(name = "software.amazon.awssdk.services.s3.S3Client")
 public class S3Config {
 
+	private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(5);
+	private static final Duration DEFAULT_SOCKET_TIMEOUT = Duration.ofSeconds(5);
+	private static final Duration DEFAULT_API_CALL_TIMEOUT = Duration.ofSeconds(5);
+	private static final Duration DEFAULT_API_CALL_ATTEMPT_TIMEOUT = Duration.ofSeconds(5);
+
 	@Value("${aws.region}")
 	private String region;
 
+	@Value("${aws.sdk.connection-timeout-seconds:5}")
+	private long connectionTimeoutSeconds;
+
+	@Value("${aws.sdk.socket-timeout-seconds:5}")
+	private long socketTimeoutSeconds;
+
+	@Value("${aws.sdk.api-call-timeout-seconds:5}")
+	private long apiCallTimeoutSeconds;
+
+	@Value("${aws.sdk.api-call-attempt-timeout-seconds:5}")
+	private long apiCallAttemptTimeoutSeconds;
+
 	@Bean
-	public S3Presigner s3Presigner() {
-		return S3Presigner.builder()
+	public StsClient awsStsClient() {
+		log.info(
+			"Initializing AWS STS client. region={}, connectionTimeoutSeconds={}, socketTimeoutSeconds={}, apiCallTimeoutSeconds={}, apiCallAttemptTimeoutSeconds={}",
+			region,
+			connectionTimeoutSeconds,
+			socketTimeoutSeconds,
+			apiCallTimeoutSeconds,
+			apiCallAttemptTimeoutSeconds
+		);
+
+		return StsClient.builder()
 			.region(Region.of(region))
+			.httpClientBuilder(apacheHttpClientBuilder())
+			.overrideConfiguration(clientOverrideConfiguration())
 			.build();
 	}
 
 	@Bean
-	public S3Client s3Client() {
+	public AwsCredentialsProvider awsCredentialsProvider(StsClient awsStsClient) {
+		boolean roleArnPresent = StringUtils.hasText(System.getenv("AWS_ROLE_ARN"));
+		boolean tokenFilePresent = StringUtils.hasText(System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"));
+		boolean metadataDisabled = Boolean.parseBoolean(
+			System.getProperty(
+				"aws.disableEc2Metadata",
+				System.getenv().getOrDefault("AWS_EC2_METADATA_DISABLED", "false")
+			)
+		);
+
+		log.info(
+			"Initializing AWS credentials provider. region={}, roleArnPresent={}, webIdentityTokenPresent={}, metadataDisabled={}",
+			region,
+			roleArnPresent,
+			tokenFilePresent,
+			metadataDisabled
+		);
+
+		DefaultCredentialsProvider fallbackProvider = DefaultCredentialsProvider.builder()
+			.asyncCredentialUpdateEnabled(false)
+			.reuseLastProviderEnabled(true)
+			.build();
+
+		if (!roleArnPresent || !tokenFilePresent) {
+			log.warn(
+				"AWS IRSA environment variables are incomplete. Falling back to DefaultCredentialsProvider. roleArnPresent={}, webIdentityTokenPresent={}",
+				roleArnPresent,
+				tokenFilePresent
+			);
+			return fallbackProvider;
+		}
+
+		AwsCredentialsProvider credentialsProvider = AwsCredentialsProviderChain.builder()
+			.reuseLastProviderEnabled(true)
+			.credentialsProviders(
+				StsWebIdentityTokenFileCredentialsProvider.builder()
+					.stsClient(awsStsClient)
+					.roleArn(System.getenv("AWS_ROLE_ARN"))
+					.webIdentityTokenFile(Path.of(System.getenv("AWS_WEB_IDENTITY_TOKEN_FILE")))
+					.roleSessionName(resolveRoleSessionName())
+					.build(),
+				fallbackProvider
+			)
+			.build();
+
+		log.info("AWS credentials provider initialized with IRSA-first chain.");
+		return credentialsProvider;
+	}
+
+	@Bean
+	public S3Presigner s3Presigner(AwsCredentialsProvider awsCredentialsProvider) {
+		log.info("Initializing AWS S3 presigner. region={}", region);
+		return S3Presigner.builder()
+			.region(Region.of(region))
+			.credentialsProvider(awsCredentialsProvider)
+			.build();
+	}
+
+	@Bean
+	public S3Client s3Client(AwsCredentialsProvider awsCredentialsProvider) {
+		log.info("Initializing AWS S3 client. region={}", region);
 		return S3Client.builder()
 			.region(Region.of(region))
+			.credentialsProvider(awsCredentialsProvider)
+			.httpClientBuilder(apacheHttpClientBuilder())
+			.overrideConfiguration(clientOverrideConfiguration())
 			.build();
+	}
+
+	private ApacheHttpClient.Builder apacheHttpClientBuilder() {
+		return ApacheHttpClient.builder()
+			.connectionTimeout(durationOrDefault(connectionTimeoutSeconds, DEFAULT_CONNECTION_TIMEOUT))
+			.socketTimeout(durationOrDefault(socketTimeoutSeconds, DEFAULT_SOCKET_TIMEOUT))
+			.connectionAcquisitionTimeout(durationOrDefault(connectionTimeoutSeconds, DEFAULT_CONNECTION_TIMEOUT));
+	}
+
+	private ClientOverrideConfiguration clientOverrideConfiguration() {
+		return ClientOverrideConfiguration.builder()
+			.apiCallTimeout(durationOrDefault(apiCallTimeoutSeconds, DEFAULT_API_CALL_TIMEOUT))
+			.apiCallAttemptTimeout(durationOrDefault(apiCallAttemptTimeoutSeconds, DEFAULT_API_CALL_ATTEMPT_TIMEOUT))
+			.build();
+	}
+
+	private String resolveRoleSessionName() {
+		String sessionName = System.getenv("AWS_ROLE_SESSION_NAME");
+		return StringUtils.hasText(sessionName) ? sessionName : "on-race-irsa-session";
+	}
+
+	private Duration durationOrDefault(long seconds, Duration defaultDuration) {
+		return seconds > 0 ? Duration.ofSeconds(seconds) : defaultDuration;
 	}
 
 }

--- a/backend/common/src/test/java/com/kt/onrace/common/config/S3ConfigTest.java
+++ b/backend/common/src/test/java/com/kt/onrace/common/config/S3ConfigTest.java
@@ -1,0 +1,95 @@
+package com.kt.onrace.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.sts.StsClient;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+@ExtendWith(SystemStubsExtension.class)
+class S3ConfigTest {
+
+	@SystemStub
+	private final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+	@SystemStub
+	private final SystemProperties systemProperties = new SystemProperties();
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void awsCredentialsProvider_fallsBackToDefaultWhenIrsaEnvMissing() {
+		environmentVariables.remove("AWS_ROLE_ARN");
+		environmentVariables.remove("AWS_WEB_IDENTITY_TOKEN_FILE");
+		systemProperties.set("aws.disableEc2Metadata", "true");
+
+		S3Config config = createConfig();
+
+		AwsCredentialsProvider credentialsProvider = config.awsCredentialsProvider(config.awsStsClient());
+
+		assertThat(credentialsProvider).isInstanceOf(DefaultCredentialsProvider.class);
+	}
+
+	@Test
+	void awsCredentialsProvider_prefersWebIdentityWhenIrsaEnvPresent() throws IOException {
+		Path tokenFile = Files.writeString(tempDir.resolve("token.jwt"), "dummy-token");
+		environmentVariables.set("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/on-race-irsa");
+		environmentVariables.set("AWS_WEB_IDENTITY_TOKEN_FILE", tokenFile.toString());
+		environmentVariables.remove("AWS_ROLE_SESSION_NAME");
+		systemProperties.set("aws.disableEc2Metadata", "true");
+
+		S3Config config = createConfig();
+
+		AwsCredentialsProvider credentialsProvider = config.awsCredentialsProvider(config.awsStsClient());
+
+		assertThat(credentialsProvider).isInstanceOf(AwsCredentialsProviderChain.class);
+	}
+
+	@Test
+	void createsAwsClientsWithConfiguredTimeouts() {
+		S3Config config = createConfig();
+		AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(
+			AwsBasicCredentials.create("accessKey", "secretKey")
+		);
+
+		try (
+			StsClient stsClient = config.awsStsClient();
+			S3Client s3Client = config.s3Client(credentialsProvider);
+			S3Presigner s3Presigner = config.s3Presigner(credentialsProvider)
+		) {
+			assertThat(stsClient).isNotNull();
+			assertThat(s3Client).isNotNull();
+			assertThat(s3Presigner).isNotNull();
+		}
+	}
+
+	private S3Config createConfig() {
+		S3Config config = new S3Config();
+		ReflectionTestUtils.setField(config, "region", "ap-northeast-2");
+		ReflectionTestUtils.setField(config, "connectionTimeoutSeconds", 5L);
+		ReflectionTestUtils.setField(config, "socketTimeoutSeconds", 5L);
+		ReflectionTestUtils.setField(config, "apiCallTimeoutSeconds", 5L);
+		ReflectionTestUtils.setField(config, "apiCallAttemptTimeoutSeconds", 5L);
+		return config;
+	}
+
+}

--- a/backend/main/src/main/resources/application.yml
+++ b/backend/main/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
         enabled: ${MAIN_REDIS_SSL_ENABLED:false}
 
 server:
-  port: ${MAIN_SERVER_PORT:8082}
+  port: ${MAIN_SERVER_PORT:8080}
   forward-headers-strategy: framework
 
 jwt:
@@ -54,6 +54,11 @@ entry:
 
 aws:
   region: ${AWS_REGION:ap-northeast-2}
+  sdk:
+    connection-timeout-seconds: ${AWS_SDK_CONNECTION_TIMEOUT_SECONDS:5}
+    socket-timeout-seconds: ${AWS_SDK_SOCKET_TIMEOUT_SECONDS:5}
+    api-call-timeout-seconds: ${AWS_SDK_API_CALL_TIMEOUT_SECONDS:5}
+    api-call-attempt-timeout-seconds: ${AWS_SDK_API_CALL_ATTEMPT_TIMEOUT_SECONDS:5}
   s3:
     bucket: ${AWS_S3_BUCKET}
     presign-expire-seconds: ${AWS_S3_PRESIGN_EXPIRE_SECONDS}

--- a/backend/main/src/main/resources/logback-spring.xml
+++ b/backend/main/src/main/resources/logback-spring.xml
@@ -57,6 +57,7 @@
         </springProfile>
 
         <springProfile name="prod">
+            <logger name="com.kt.onrace.common.config" level="INFO"/>
             <logger name="com.kt.onrace" level="WARN"/>
 
             <root level="WARN">

--- a/backend/queue/src/main/resources/application.yml
+++ b/backend/queue/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${QUEUE_SERVER_PORT:8083}
+  port: ${QUEUE_SERVER_PORT:8082}
 
 spring:
   application:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,7 @@ sonar.projectName=On-Race
 sonar.sources=backend/auth/src/main,backend/common/src/main,backend/gateway/src/main,backend/main/src/main,backend/queue/src/main,frontend/src
 
 # Test directories
-sonar.tests=backend/auth/src/test,backend/main/src/test
+sonar.tests=backend/auth/src/test,backend/common/src/test,backend/main/src/test
 
 # TypeScript / JavaScript settings (Frontend)
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info
@@ -21,7 +21,7 @@ sonar.typescript.tsconfigPath=frontend/tsconfig.json
 # Java settings (Backend)
 sonar.java.source=21
 sonar.java.binaries=backend/auth/build/classes/java/main,backend/main/build/classes/java/main,backend/common/build/classes/java/main,backend/gateway/build/classes/java/main,backend/queue/build/classes/java/main
-sonar.coverage.jacoco.xmlReportPaths=backend/auth/build/reports/jacoco/test/jacocoTestReport.xml,backend/main/build/reports/jacoco/test/jacocoTestReport.xml
+sonar.coverage.jacoco.xmlReportPaths=backend/auth/build/reports/jacoco/test/jacocoTestReport.xml,backend/common/build/reports/jacoco/test/jacocoTestReport.xml,backend/main/build/reports/jacoco/test/jacocoTestReport.xml
 
 # Exclusions
 sonar.exclusions=**/node_modules/**,**/dist/**,**/build/**,**/coverage/**,**/.pnpm-store/**


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)

- `main` 기본 포트를 `8080`으로, `queue` 기본 포트를 `8082`로 조정해 현재 K8s startup/readiness probe 포트와 맞췄습니다.
- 공통 AWS SDK 설정에 IRSA 우선 credential chain을 추가했습니다.
  `WebIdentity` 우선, 실패 시 `DefaultCredentialsProvider` fallback
- STS/S3 client에 5초 내외 timeout을 추가해 AWS 초기화 hang 시 빠르게 실패하도록 변경했습니다.
- 이미지 런타임에 `AWS_EC2_METADATA_DISABLED=true` 및 JVM metadata disable 옵션을 적용했습니다.
- prod 환경에서 AWS 초기화 구간 로그가 보이도록 logger를 추가했습니다.

## 📸 스크린샷 / 아키텍처 / 로그 (필수)

### 빌드 검증 로그
```text
> Task :main:bootJar
> Task :queue:bootJar

BUILD SUCCESSFUL in 13s
10 actionable tasks: 9 executed, 1 up-to-date
```

### 장애 원인 요약
```text
before
- main default port: 8082 / probe: 8080
- queue default port: 8083 / probe: 8082
- AWS SDK default credential chain 사용
- EC2 metadata fallback 차단 없음
- AWS 초기화 구간 로그 없음

after
- main default port: 8080
- queue default port: 8082
- IRSA-first credentials provider 적용
- STS/S3 timeout 적용
- EC2 metadata 비활성화 적용
- AWS 초기화 로그 추가
```

### 코드베이스 확인 로그
```text
repo search result
- no @SqsListener
- no SqsClient
- no spring.cloud.aws
- no DescribeQueue path
```

## ❓ 변경 이유 (Why)

- 포트 변경:
  현재 배포된 K8s probe 포트와 앱 기본 포트가 서로 달라 `Startup probe failed: connection refused`가 발생할 수 있었습니다.
- AWS 초기화 보강:
  EC2 metadata/credential resolution 단계가 길어지면 Tomcat이 포트를 열기 전에 부팅이 멈춘 것처럼 보일 수 있어, IRSA 우선 사용과 metadata 비활성화, 짧은 timeout을 적용했습니다.

## 📋 체크리스트

- [ ] 로컬 환경에서 빌드 및 테스트 성공 확인
- [ ] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [ ] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

참고:
- 로컬에서는 `main`/`queue` `bootJar` 빌드만 확인했고, 전체 테스트는 실행하지 않았습니다.
- 이번 변경에서 AWS Key/DB 비번 하드코딩을 추가하진 않았지만, 저장소 전체의 기존 시크릿 주입 방식은 별도 점검이 필요합니다.
- 공통 `Dockerfile`을 건드렸기 때문에 `auth`/`gateway` 이미지 영향은 추가 확인이 필요합니다.

## 🔗 관련 이슈

Resolves: #