### PR TITLE
feat(backend): 대기열 병목 지점 개선

### DIFF
--- a/backend/main/build.gradle
+++ b/backend/main/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // CACHE
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     // UTILS
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryPersistService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryPersistService.java
@@ -1,0 +1,54 @@
+package com.kt.onrace.domain.entry.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.common.util.Preconditions;
+import com.kt.onrace.domain.entry.entity.Entry;
+import com.kt.onrace.domain.entry.entity.EntryStatus;
+import com.kt.onrace.domain.entry.repository.EntryRepository;
+import com.kt.onrace.domain.event.entity.Event;
+import com.kt.onrace.domain.event.entity.EventCourse;
+import com.kt.onrace.domain.event.entity.EventPace;
+
+import lombok.RequiredArgsConstructor;
+
+// Entry 영속화 전용 서비스
+// DB 쓰기 작업만 분리
+@Service
+@RequiredArgsConstructor
+public class EntryPersistService {
+
+	private final EntryRepository entryRepository;
+
+	@Transactional
+	public Entry applyLotteryEntry(Long userId, Event event, EventCourse course, EventPace pace) {
+		Entry entry = findOrCreateEntry(userId, event);
+		entry.apply(course, pace);
+		return entryRepository.save(entry);
+	}
+
+	@Transactional
+	public Entry reserveFirstComeEntry(Long userId, Event event, EventCourse course, EventPace pace) {
+		Entry entry = findOrCreateEntry(userId, event);
+		entry.reserve(course, pace);
+		return entryRepository.save(entry);
+	}
+
+	private Entry findOrCreateEntry(Long userId, Event event) {
+		return entryRepository.findByUserIdAndEventId(userId, event.getId())
+			.map(e -> {
+				Preconditions.validate(e.getStatus() != EntryStatus.APPLIED,
+					BusinessErrorCode.ENTRY_ALREADY_APPLIED);
+				Preconditions.validate(
+					e.getStatus() == EntryStatus.RESERVED || e.getStatus() == EntryStatus.PRE_SAVED,
+					BusinessErrorCode.ENTRY_CANNOT_APPLY);
+				return e;
+			})
+			.orElseGet(() -> Entry.builder()
+				.userId(userId)
+				.event(event)
+				.build());
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -31,6 +31,7 @@ import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
 import com.kt.onrace.domain.event.repository.EventStockRepository;
+import com.kt.onrace.domain.event.service.EventCacheService;
 import com.kt.onrace.domain.event.service.EventStockService;
 import com.kt.onrace.domain.member.repository.MemberRepository;
 
@@ -52,6 +53,7 @@ public class EntryService {
 	private final EventStockService eventStockService;
 	private final EventStockRepository eventStockRepository;
 	private final EntryMetrics entryMetrics;
+	private final EventCacheService eventCacheService;
 
 	@ServiceLog(slowMs = 2000)
 	@Transactional
@@ -168,10 +170,7 @@ public class EntryService {
 			Preconditions.validate(queuePaceId.equals(request.paceId()), BusinessErrorCode.ENTRY_QUEUE_PACE_MISMATCH);
 		}
 
-		memberRepository.findByIdAndIsDeletedFalseOrThrow(userId, BusinessErrorCode.MEMBER_NOT_FOUND);
-
-		Event event = eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eventId,
-				BusinessErrorCode.EVENT_NOT_FOUND);
+		Event event = eventCacheService.getEvent(eventId);
 
 		Preconditions.validate(event.getAppType() == expectedAppType, BusinessErrorCode.ENTRY_APP_TYPE_MISMATCH);
 
@@ -180,11 +179,8 @@ public class EntryService {
 		Preconditions.validate(!now.isBefore(event.getAppStartAt()) && !now.isAfter(event.getAppEndAt()),
 				BusinessErrorCode.ENTRY_NOT_IN_PERIOD);
 
-		EventCourse course = eventCourseRepository.findByIdAndEventIdOrThrow(request.courseId(), eventId,
-				BusinessErrorCode.ENTRY_COURSE_NOT_FOUND);
-
-		EventPace pace = eventPaceRepository.findByIdAndEventCourseIdOrThrow(request.paceId(), request.courseId(),
-				BusinessErrorCode.ENTRY_PACE_NOT_FOUND);
+		EventCourse course = eventCacheService.getCourse(request.courseId(), eventId);
+		EventPace pace = eventCacheService.getPace(request.paceId(), request.courseId());
 
 		log.info("[ENTRY] 신청 시작 userId={}, eventId={}, appType={}, courseId={}, paceId={}",
 			userId, eventId, expectedAppType, request.courseId(), request.paceId());

--- a/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/entry/service/EntryService.java
@@ -4,7 +4,9 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.onrace.common.exception.BusinessErrorCode;
@@ -27,6 +29,7 @@ import com.kt.onrace.domain.event.entity.EventAppType;
 import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventStatus;
+import com.kt.onrace.domain.event.event.StockConfirmEvent;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
@@ -54,6 +57,8 @@ public class EntryService {
 	private final EventStockRepository eventStockRepository;
 	private final EntryMetrics entryMetrics;
 	private final EventCacheService eventCacheService;
+	private final EntryPersistService entryPersistService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@ServiceLog(slowMs = 2000)
 	@Transactional
@@ -163,7 +168,7 @@ public class EntryService {
 	}
 
 	@ServiceLog(slowMs = 2000)
-	@Transactional
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public EntryApplyResponse apply(Long userId, Long eventId, EntryCoursePaceRequest request,
 			Long queuePaceId, EventAppType expectedAppType) {
 		if (queuePaceId != null) {
@@ -192,9 +197,7 @@ public class EntryService {
 	}
 
 	private EntryApplyResponse applyLottery(Long userId, Event event, EventCourse course, EventPace pace) {
-		Entry entry = getCreateEntry(userId, event);
-		entry.apply(course, pace);
-		entryRepository.save(entry);
+		Entry entry = entryPersistService.applyLotteryEntry(userId, event, course, pace);
 		entryMetrics.recordApply("LOTTERY", "success");
 
 		log.info("[ENTRY] 추첨 신청 완료 userId={}, eventId={}, entryId={}", userId, event.getId(), entry.getId());
@@ -203,49 +206,32 @@ public class EntryService {
 	}
 
 	private EntryApplyResponse applyFirstCome(Long userId, Event event, EventCourse course, EventPace pace) {
-		Entry entry = getCreateEntry(userId, event);
-
-		if (entry.isReserved()) {
-			long remainingMs = eventStockService.getReservationTtl(entry.getEventPace().getId(), userId);
-			if (remainingMs > 0) {
-				return EntryApplyResponse.fromReserved(entry, LocalDateTime.now().plus(Duration.ofMillis(remainingMs)));
-			}
-		}
-
 		long result = eventStockService.tryReserveStock(pace.getId(), userId);
 
 		if (result == -2) {
+			// 이미 선점된 사용자 — 활성 예약이면 기존 예약 정보 반환
+			long remainingMs = eventStockService.getReservationTtl(pace.getId(), userId);
+			if (remainingMs > 0) {
+				Entry entry = entryRepository.findByUserIdAndEventId(userId, event.getId())
+					.orElseThrow(() -> new BusinessException(BusinessErrorCode.ENTRY_NOT_FOUND));
+				return EntryApplyResponse.fromReserved(entry, LocalDateTime.now().plus(Duration.ofMillis(remainingMs)));
+			}
 			entryMetrics.recordApply("FIRST_COME", "duplicate");
 			log.info("[ENTRY] 중복 선점 시도 userId={}, paceId={}", userId, pace.getId());
-		} else if (result == -1) {
-			entryMetrics.recordApply("FIRST_COME", "sold_out");
-			log.info("[ENTRY] 선착순 매진 userId={}, paceId={}", userId, pace.getId());
+			throw new BusinessException(BusinessErrorCode.ENTRY_ALREADY_RESERVED);
 		}
 
-		Preconditions.validate(result != -2, BusinessErrorCode.ENTRY_ALREADY_RESERVED);
-		Preconditions.validate(result != -1, BusinessErrorCode.ENTRY_SOLD_OUT);
+		if (result == -1) {
+			entryMetrics.recordApply("FIRST_COME", "sold_out");
+			log.info("[ENTRY] 선착순 매진 userId={}, paceId={}", userId, pace.getId());
+			throw new BusinessException(BusinessErrorCode.ENTRY_SOLD_OUT);
+		}
 
 		entryMetrics.recordApply("FIRST_COME", "success");
 		log.info("[ENTRY] 선착순 선점 성공 userId={}, paceId={}, remaining={}", userId, pace.getId(), result);
 
-		entry.reserve(course, pace);
-		entryRepository.save(entry);
-
+		Entry entry = entryPersistService.reserveFirstComeEntry(userId, event, course, pace);
 		return EntryApplyResponse.fromReserved(entry, LocalDateTime.now().plusSeconds(entryProperties.getTtlSeconds()));
-	}
-
-	private Entry getCreateEntry(Long userId, Event event) {
-		return entryRepository.findByUserIdAndEventId(userId, event.getId())
-				.map(e -> {
-					Preconditions.validate(e.getStatus() != EntryStatus.APPLIED, BusinessErrorCode.ENTRY_ALREADY_APPLIED);
-					Preconditions.validate(e.getStatus() == EntryStatus.RESERVED || e.getStatus() == EntryStatus.PRE_SAVED,
-						BusinessErrorCode.ENTRY_CANNOT_APPLY);
-					return e;
-				})
-				.orElseGet(() -> Entry.builder()
-						.userId(userId)
-						.event(event)
-						.build());
 	}
 
 	@ServiceLog
@@ -290,11 +276,9 @@ public class EntryService {
 		entryMetrics.recordConfirm(type.name());
 		log.info("[ENTRY] 결제 확정 userId={}, paceId={}, appType={}", userId, paceId, type);
 
-		// 왜? 위의 if로 넣지 않느냐 -> 트랜잭션 커밋이 안된 상태에서 redis는 즉시 실행되고 DB 업데이트는 트랜잭션 커밋 시점에 반영되기
-		// 때문에 DB가 실패할 시 redis는 롤백이 안되므로, DB가 성공적으로 끝난 후 redis를 실행하는 것이 맞음
+		// TX 커밋 후 Redis 작업 실행 (DB 롤백 시 Redis 불일치 방지)
 		if(type == EventAppType.FIRST_COME) {
-			eventStockService.deleteReservation(paceId, userId);
-			eventStockService.confirmStock(paceId);
+			eventPublisher.publishEvent(new StockConfirmEvent(paceId, userId));
 		}
 	}
 

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/event/StockConfirmEvent.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/event/StockConfirmEvent.java
@@ -1,0 +1,5 @@
+package com.kt.onrace.domain.event.event;
+
+// 재고 확정 도메인 이벤트
+public record StockConfirmEvent(Long paceId, Long userId) {
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/listener/StockConfirmEventListener.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/listener/StockConfirmEventListener.java
@@ -1,0 +1,25 @@
+package com.kt.onrace.domain.event.listener;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.kt.onrace.domain.event.event.StockConfirmEvent;
+import com.kt.onrace.domain.event.service.EventStockService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockConfirmEventListener {
+
+	private final EventStockService eventStockService;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onStockConfirm(StockConfirmEvent event) {
+		eventStockService.confirmAndDeleteReservation(event.paceId(), event.userId());
+		log.info("[STOCK] 커밋 후 Redis 확정 paceId={}, userId={}", event.paceId(), event.userId());
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventCacheService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventCacheService.java
@@ -1,0 +1,72 @@
+package com.kt.onrace.domain.event.service;
+
+import java.time.Duration;
+
+import org.springframework.stereotype.Service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.kt.onrace.common.exception.BusinessErrorCode;
+import com.kt.onrace.domain.event.entity.Event;
+import com.kt.onrace.domain.event.entity.EventCourse;
+import com.kt.onrace.domain.event.entity.EventPace;
+import com.kt.onrace.domain.event.repository.EventCourseRepository;
+import com.kt.onrace.domain.event.repository.EventPaceRepository;
+import com.kt.onrace.domain.event.repository.EventRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class EventCacheService {
+
+	private final EventRepository eventRepository;
+	private final EventCourseRepository eventCourseRepository;
+	private final EventPaceRepository eventPaceRepository;
+
+	private final Cache<Long, Event> eventCache;
+	private final Cache<String, EventCourse> courseCache;
+	private final Cache<String, EventPace> paceCache;
+
+	public EventCacheService(EventRepository eventRepository,
+		EventCourseRepository eventCourseRepository,
+		EventPaceRepository eventPaceRepository) {
+		this.eventRepository = eventRepository;
+		this.eventCourseRepository = eventCourseRepository;
+		this.eventPaceRepository = eventPaceRepository;
+
+		this.eventCache = Caffeine.newBuilder()
+			.maximumSize(200)
+			.expireAfterWrite(Duration.ofSeconds(30))
+			.build();
+
+		this.courseCache = Caffeine.newBuilder()
+			.maximumSize(200)
+			.expireAfterWrite(Duration.ofSeconds(30))
+			.build();
+
+		this.paceCache = Caffeine.newBuilder()
+			.maximumSize(200)
+			.expireAfterWrite(Duration.ofSeconds(30))
+			.build();
+	}
+
+	public Event getEvent(Long eventId) {
+		return eventCache.get(eventId, id ->
+			eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(id, BusinessErrorCode.EVENT_NOT_FOUND));
+	}
+
+	public EventCourse getCourse(Long courseId, Long eventId) {
+		String key = eventId + ":" + courseId;
+		return courseCache.get(key, k ->
+			eventCourseRepository.findByIdAndEventIdOrThrow(courseId, eventId,
+				BusinessErrorCode.ENTRY_COURSE_NOT_FOUND));
+	}
+
+	public EventPace getPace(Long paceId, Long courseId) {
+		String key = courseId + ":" + paceId;
+		return paceCache.get(key, k ->
+			eventPaceRepository.findByIdAndEventCourseIdOrThrow(paceId, courseId,
+				BusinessErrorCode.ENTRY_PACE_NOT_FOUND));
+	}
+}

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -23,6 +23,11 @@ public class EventStockService {
 	private final EntryProperties entryProperties;
 	private final StockMetrics stockMetrics;
 
+	private static final String CONFIRM_AND_DELETE_SCRIPT =
+		"redis.call('DEL', KEYS[1]) " +
+			"redis.call('INCR', KEYS[2]) " +
+			"return 1";
+
 	private static final String RESERVE_SCRIPT =
 		"if redis.call('EXISTS', KEYS[1]) == 1 then return -2 end " +
 			"local stock = redis.call('DECR', KEYS[2]) " +
@@ -118,6 +123,17 @@ public class EventStockService {
 		RAtomicLong stock = redissonClient.getAtomicLong(RedisKeyGenerator.confirmStockKey(paceId));
 		stock.incrementAndGet();
 		log.info("[STOCK] 재고 확정 paceId={}", paceId);
+	}
+
+	public void confirmAndDeleteReservation(Long paceId, Long userId) {
+		RScript script = redissonClient.getScript(StringCodec.INSTANCE);
+		script.eval(
+			RScript.Mode.READ_WRITE,
+			CONFIRM_AND_DELETE_SCRIPT,
+			RScript.ReturnType.INTEGER,
+			List.of(RedisKeyGenerator.reservationKey(paceId, userId), RedisKeyGenerator.confirmStockKey(paceId))
+		);
+		log.info("[STOCK] 예약 삭제 + 재고 확정 paceId={}, userId={}", paceId, userId);
 	}
 
 	public void cancelConfirmedStock(Long paceId) {

--- a/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
+++ b/backend/main/src/main/java/com/kt/onrace/domain/event/service/EventStockService.java
@@ -24,8 +24,8 @@ public class EventStockService {
 	private final StockMetrics stockMetrics;
 
 	private static final String CONFIRM_AND_DELETE_SCRIPT =
-		"redis.call('DEL', KEYS[1]) " +
-			"redis.call('INCR', KEYS[2]) " +
+		"redis.call('DEL', KEYS[1]); " +
+			"redis.call('INCR', KEYS[2]); " +
 			"return 1";
 
 	private static final String RESERVE_SCRIPT =

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.kt.onrace.common.exception.BusinessErrorCode;
 import com.kt.onrace.common.exception.BusinessException;
@@ -37,6 +38,7 @@ import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventRegion;
 import com.kt.onrace.domain.event.entity.EventType;
+import com.kt.onrace.domain.event.event.StockConfirmEvent;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
@@ -63,6 +65,8 @@ class EntryServiceTest {
 	@Mock private EventStockRepository eventStockRepository;
 	@Mock private EntryMetrics entryMetrics;
 	@Mock private EventCacheService eventCacheService;
+	@Mock private EntryPersistService entryPersistService;
+	@Mock private ApplicationEventPublisher eventPublisher;
 
 	@InjectMocks
 	private EntryService entryService;
@@ -120,15 +124,17 @@ class EntryServiceTest {
 		EventPace pace = createPace(course);
 		setId(pace, PACE_ID);
 
+		Entry appliedEntry = Entry.builder()
+			.userId(USER_ID).event(event).eventCourse(course).eventPace(pace)
+			.status(EntryStatus.APPLIED).build();
+
 		stubCommonApplyDependencies(event, course, pace);
-		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
-		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
+		when(entryPersistService.applyLotteryEntry(USER_ID, event, course, pace)).thenReturn(appliedEntry);
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.LOTTERY);
 
-		verify(entryRepository).save(entryCaptor.capture());
-		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.APPLIED);
+		verify(entryPersistService).applyLotteryEntry(USER_ID, event, course, pace);
 		assertThat(response.status()).isEqualTo(EntryStatus.APPLIED.getDescription());
 	}
 
@@ -141,17 +147,19 @@ class EntryServiceTest {
 		EventPace pace = createPace(course);
 		setId(pace, PACE_ID);
 
+		Entry reservedEntry = Entry.builder()
+			.userId(USER_ID).event(event).eventCourse(course).eventPace(pace)
+			.status(EntryStatus.RESERVED).build();
+
 		stubCommonApplyDependencies(event, course, pace);
-		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
 		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(1L);
 		when(entryProperties.getTtlSeconds()).thenReturn(600L);
-		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
+		when(entryPersistService.reserveFirstComeEntry(USER_ID, event, course, pace)).thenReturn(reservedEntry);
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME);
 
-		verify(entryRepository).save(entryCaptor.capture());
-		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.RESERVED);
+		verify(entryPersistService).reserveFirstComeEntry(USER_ID, event, course, pace);
 		assertThat(response.status()).isEqualTo(EntryStatus.RESERVED.getDescription());
 		assertThat(response.reservedUntil()).isNotNull();
 	}
@@ -166,7 +174,6 @@ class EntryServiceTest {
 		setId(pace, PACE_ID);
 
 		stubCommonApplyDependencies(event, course, pace);
-		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
 		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(-1L);
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
@@ -187,8 +194,8 @@ class EntryServiceTest {
 		setId(pace, PACE_ID);
 
 		stubCommonApplyDependencies(event, course, pace);
-		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID)).thenReturn(Optional.empty());
 		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(-2L);
+		when(eventStockService.getReservationTtl(PACE_ID, USER_ID)).thenReturn(-2L);
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 
@@ -199,7 +206,7 @@ class EntryServiceTest {
 	}
 
 	@Test
-	@DisplayName("선착순 신청 시 DB에 RESERVED 엔트리가 있고 Redis 예약이 활성이면 기존 예약 정보를 반환한다")
+	@DisplayName("선착순 신청 시 Redis에 활성 예약이 있으면 기존 예약 정보를 반환한다")
 	void apply_firstComeReservedWithActiveReservation() {
 		Event event = createEvent(EventAppType.FIRST_COME);
 		setId(event, EVENT_ID);
@@ -216,20 +223,21 @@ class EntryServiceTest {
 			.build();
 
 		stubCommonApplyDependencies(event, course, pace);
+		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(-2L);
+		when(eventStockService.getReservationTtl(PACE_ID, USER_ID)).thenReturn(300_000L);
 		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID))
 			.thenReturn(Optional.of(existingEntry));
-		when(eventStockService.getReservationTtl(PACE_ID, USER_ID)).thenReturn(300_000L);
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME);
 
 		assertThat(response.status()).isEqualTo(EntryStatus.RESERVED.getDescription());
 		assertThat(response.reservedUntil()).isNotNull();
-		verify(eventStockService, never()).tryReserveStock(any(), any());
+		verify(entryPersistService, never()).reserveFirstComeEntry(any(), any(), any(), any());
 	}
 
 	@Test
-	@DisplayName("선착순 신청 시 DB에 RESERVED 엔트리가 있지만 Redis 예약이 만료되었으면 재신청에 성공한다")
+	@DisplayName("선착순 신청 시 Redis 예약 만료 후 재신청에 성공한다")
 	void apply_firstComeReservedWithExpiredReservation() {
 		Event event = createEvent(EventAppType.FIRST_COME);
 		setId(event, EVENT_ID);
@@ -237,27 +245,19 @@ class EntryServiceTest {
 		EventPace pace = createPace(course);
 		setId(pace, PACE_ID);
 
-		Entry existingEntry = Entry.builder()
-			.userId(USER_ID)
-			.event(event)
-			.eventCourse(course)
-			.eventPace(pace)
-			.status(EntryStatus.RESERVED)
-			.build();
+		Entry reservedEntry = Entry.builder()
+			.userId(USER_ID).event(event).eventCourse(course).eventPace(pace)
+			.status(EntryStatus.RESERVED).build();
 
 		stubCommonApplyDependencies(event, course, pace);
-		when(entryRepository.findByUserIdAndEventId(USER_ID, EVENT_ID))
-			.thenReturn(Optional.of(existingEntry));
-		when(eventStockService.getReservationTtl(PACE_ID, USER_ID)).thenReturn(-2L);
 		when(eventStockService.tryReserveStock(PACE_ID, USER_ID)).thenReturn(1L);
 		when(entryProperties.getTtlSeconds()).thenReturn(600L);
-		when(entryRepository.save(any(Entry.class))).thenAnswer(inv -> inv.getArgument(0));
+		when(entryPersistService.reserveFirstComeEntry(USER_ID, event, course, pace)).thenReturn(reservedEntry);
 
 		EntryCoursePaceRequest request = new EntryCoursePaceRequest(COURSE_ID, PACE_ID);
 		EntryApplyResponse response = entryService.apply(USER_ID, EVENT_ID, request, null, EventAppType.FIRST_COME);
 
-		verify(entryRepository).save(entryCaptor.capture());
-		assertThat(entryCaptor.getValue().getStatus()).isEqualTo(EntryStatus.RESERVED);
+		verify(entryPersistService).reserveFirstComeEntry(USER_ID, event, course, pace);
 		assertThat(response.status()).isEqualTo(EntryStatus.RESERVED.getDescription());
 		assertThat(response.reservedUntil()).isNotNull();
 	}
@@ -292,8 +292,7 @@ class EntryServiceTest {
 		assertThat(entry.getStatus()).isEqualTo(EntryStatus.APPLIED);
 		verify(eventStockRepository).incrementConfirmedStock(PACE_ID);
 		verify(entryMetrics).recordConfirm("FIRST_COME");
-		verify(eventStockService).deleteReservation(PACE_ID, USER_ID);
-		verify(eventStockService).confirmStock(PACE_ID);
+		verify(eventPublisher).publishEvent(new StockConfirmEvent(PACE_ID, USER_ID));
 	}
 
 	@Test

--- a/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
+++ b/backend/main/src/test/java/com/kt/onrace/domain/entry/service/EntryServiceTest.java
@@ -36,12 +36,12 @@ import com.kt.onrace.domain.event.entity.EventAppType;
 import com.kt.onrace.domain.event.entity.EventCourse;
 import com.kt.onrace.domain.event.entity.EventPace;
 import com.kt.onrace.domain.event.entity.EventRegion;
-import com.kt.onrace.domain.event.entity.EventStock;
 import com.kt.onrace.domain.event.entity.EventType;
 import com.kt.onrace.domain.event.repository.EventCourseRepository;
 import com.kt.onrace.domain.event.repository.EventPaceRepository;
 import com.kt.onrace.domain.event.repository.EventRepository;
 import com.kt.onrace.domain.event.repository.EventStockRepository;
+import com.kt.onrace.domain.event.service.EventCacheService;
 import com.kt.onrace.domain.event.service.EventStockService;
 import com.kt.onrace.domain.member.repository.MemberRepository;
 
@@ -61,6 +61,8 @@ class EntryServiceTest {
 	@Mock private MemberRepository memberRepository;
 	@Mock private EventStockService eventStockService;
 	@Mock private EventStockRepository eventStockRepository;
+	@Mock private EntryMetrics entryMetrics;
+	@Mock private EventCacheService eventCacheService;
 
 	@InjectMocks
 	private EntryService entryService;
@@ -281,18 +283,15 @@ class EntryServiceTest {
 			.userId(USER_ID)
 			.status(EntryStatus.RESERVED)
 			.build();
-		EventStock stock = EventStock.builder()
-			.totalStock(10)
-			.build();
 
 		when(entryRepository.findByUserIdAndEventPaceId(USER_ID, PACE_ID)).thenReturn(Optional.of(entry));
 		when(eventStockService.hasReservation(PACE_ID, USER_ID)).thenReturn(true);
-		when(eventStockRepository.findByEventPaceIdOrThrow(PACE_ID)).thenReturn(stock);
 
 		entryService.confirmReservation(USER_ID, PACE_ID, EventAppType.FIRST_COME);
 
 		assertThat(entry.getStatus()).isEqualTo(EntryStatus.APPLIED);
-		assertThat(stock.getConfirmedStock()).isEqualTo(1);
+		verify(eventStockRepository).incrementConfirmedStock(PACE_ID);
+		verify(entryMetrics).recordConfirm("FIRST_COME");
 		verify(eventStockService).deleteReservation(PACE_ID, USER_ID);
 		verify(eventStockService).confirmStock(PACE_ID);
 	}
@@ -344,10 +343,9 @@ class EntryServiceTest {
 	// ===== helpers =====
 
 	private void stubCommonApplyDependencies(Event event, EventCourse course, EventPace pace) {
-		when(memberRepository.findByIdAndIsDeletedFalseOrThrow(eq(USER_ID), any())).thenReturn(null);
-		when(eventRepository.findByIdAndIsViewTrueAndIsDeletedFalseOrThrow(eq(EVENT_ID), any())).thenReturn(event);
-		when(eventCourseRepository.findByIdAndEventIdOrThrow(eq(COURSE_ID), eq(EVENT_ID), any())).thenReturn(course);
-		when(eventPaceRepository.findByIdAndEventCourseIdOrThrow(eq(PACE_ID), eq(COURSE_ID), any())).thenReturn(pace);
+		when(eventCacheService.getEvent(EVENT_ID)).thenReturn(event);
+		when(eventCacheService.getCourse(COURSE_ID, EVENT_ID)).thenReturn(course);
+		when(eventCacheService.getPace(PACE_ID, COURSE_ID)).thenReturn(pace);
 	}
 
 	private Event createEvent(EventAppType appType) {

--- a/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/processor/QueueBatchScheduler.java
@@ -1,11 +1,17 @@
 package com.kt.onrace.queue.processor;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.redisson.api.RBucket;
+import org.redisson.api.BatchOptions;
+import org.redisson.api.RBatch;
+import org.redisson.api.RBucketAsync;
 import org.redisson.api.RDeque;
 import org.redisson.api.RLock;
 import org.redisson.api.RScoredSortedSet;
@@ -38,6 +44,14 @@ public class QueueBatchScheduler {
 	private static final long LOCK_LEASE_SECONDS = 30;
 	private static final int MAX_RETRY_COUNT = 3;
 	private static final String RETRY_SEPARATOR = ":";
+	private static final int PACE_THREAD_POOL_SIZE = 8;
+
+	private final ExecutorService paceExecutor = Executors.newFixedThreadPool(PACE_THREAD_POOL_SIZE,
+		r -> {
+			Thread t = new Thread(r, "queue-pace-worker");
+			t.setDaemon(true);
+			return t;
+		});
 
 	// 대기열(waiting)과 재시도 큐(retry)가 모두 비어있을 때만 activePaces에서 제거
 	private static final String REMOVE_IF_EMPTY_SCRIPT =
@@ -55,14 +69,18 @@ public class QueueBatchScheduler {
 			RSet<String> activePaces = redissonClient.getSet(RedisKeyGenerator.queueActivePaces(), StringCodec.INSTANCE);
 			Set<String> paceIds = activePaces.readAll();
 
-			for (String paceIdStr : paceIds) {
-				try {
-					Long paceId = Long.parseLong(paceIdStr);
-					processPaceQueue(paceId);
-				} catch (Exception e) {
-					log.error("배치 처리 오류 - paceId={}, error={}", paceIdStr, e.getMessage());
-				}
-			}
+			List<CompletableFuture<Void>> futures = paceIds.stream()
+				.map(paceIdStr -> CompletableFuture.runAsync(() -> {
+					try {
+						Long paceId = Long.parseLong(paceIdStr);
+						processPaceQueue(paceId);
+					} catch (Exception e) {
+						log.error("배치 처리 오류 - paceId={}, error={}", paceIdStr, e.getMessage());
+					}
+				}, paceExecutor))
+				.toList();
+
+			CompletableFuture.allOf(futures.toArray(CompletableFuture[]::new)).join();
 		} finally {
 			queueMetrics.stopBatchTimer(sample);
 		}
@@ -113,6 +131,8 @@ public class QueueBatchScheduler {
 		}
 	}
 
+	private record PassTokenEntry(String userIdStr, String passKey, String passToken, int retryCount) {}
+
 	private int processWaitingQueue(RScoredSortedSet<String> waitingSet, Long paceId, long passTtl,
 		RDeque<String> retryQueue, int count) {
 		if (count <= 0) {
@@ -122,24 +142,32 @@ public class QueueBatchScheduler {
 		if (popped == null || popped.isEmpty()) {
 			return 0;
 		}
-		int issued = 0;
+
+		List<PassTokenEntry> entries = new ArrayList<>();
 		for (String userIdStr : popped) {
 			if (userIdStr == null) {
 				continue;
 			}
-			if (issuePassToken(userIdStr, paceId, passTtl, retryQueue, 0)) {
-				issued++;
+			try {
+				Long userId = Long.parseLong(userIdStr);
+				String passKey = RedisKeyGenerator.queuePass(paceId, userId);
+				String passToken = queueTokenGenerator.generatePassToken(userId, paceId);
+				entries.add(new PassTokenEntry(userIdStr, passKey, passToken, 0));
+			} catch (Exception e) {
+				log.error("통과 토큰 생성 실패, 재시도 큐 등록 (1/{}) - paceId={}, userId={}",
+					MAX_RETRY_COUNT, paceId, userIdStr, e);
+				retryQueue.addLast(userIdStr + RETRY_SEPARATOR + 1);
 			}
 		}
-		return issued;
+
+		return executeTokenBatch(entries, paceId, passTtl, retryQueue);
 	}
 
 	private int processRetryQueue(RDeque<String> retryQueue, Long paceId, long passTtl, int batchSize) {
-		int issued = 0;
+		List<PassTokenEntry> entries = new ArrayList<>();
 
 		String entry;
-
-		while (issued < batchSize && (entry = retryQueue.pollFirst()) != null) {
+		while (entries.size() < batchSize && (entry = retryQueue.pollFirst()) != null) {
 			String userId = parseUserId(entry);
 			int retryCount = parseRetryCount(entry);
 
@@ -148,28 +176,46 @@ public class QueueBatchScheduler {
 				continue;
 			}
 
-			if (issuePassToken(userId, paceId, passTtl, retryQueue, retryCount)) {
-				issued++;
+			try {
+				Long userIdLong = Long.parseLong(userId);
+				String passKey = RedisKeyGenerator.queuePass(paceId, userIdLong);
+				String passToken = queueTokenGenerator.generatePassToken(userIdLong, paceId);
+				entries.add(new PassTokenEntry(userId, passKey, passToken, retryCount));
+			} catch (Exception e) {
+				int nextRetry = retryCount + 1;
+				log.error("통과 토큰 생성 실패, 재시도 큐 등록 ({}/{}) - paceId={}, userId={}",
+					nextRetry, MAX_RETRY_COUNT, paceId, userId, e);
+				retryQueue.addLast(userId + RETRY_SEPARATOR + nextRetry);
 			}
 		}
-		return issued;
+
+		return executeTokenBatch(entries, paceId, passTtl, retryQueue);
 	}
 
-	private boolean issuePassToken(String userIdStr, Long paceId, long passTtl, RDeque<String> retryQueue, int retryCount) {
+	private int executeTokenBatch(List<PassTokenEntry> entries, Long paceId, long passTtl, RDeque<String> retryQueue) {
+		if (entries.isEmpty()) {
+			return 0;
+		}
+
 		try {
-			Long userId = Long.parseLong(userIdStr);
-			String passKey = RedisKeyGenerator.queuePass(paceId, userId);
-			String passToken = queueTokenGenerator.generatePassToken(userId, paceId);
-			RBucket<String> passBucket = redissonClient.getBucket(passKey, StringCodec.INSTANCE);
-			passBucket.set(passToken, passTtl, TimeUnit.SECONDS);
-			log.debug("[QUEUE] 통과 토큰 발급 userId={}, paceId={}", userId, paceId);
-			return true;
+			RBatch batch = redissonClient.createBatch(BatchOptions.defaults());
+			for (PassTokenEntry entry : entries) {
+				RBucketAsync<String> bucket = batch.getBucket(entry.passKey(), StringCodec.INSTANCE);
+				bucket.setAsync(entry.passToken(), passTtl, TimeUnit.SECONDS);
+			}
+			batch.execute();
+
+			for (PassTokenEntry entry : entries) {
+				log.debug("[QUEUE] 통과 토큰 발급 userId={}, paceId={}", entry.userIdStr(), paceId);
+			}
+			return entries.size();
 		} catch (Exception e) {
-			int nextRetry = retryCount + 1;
-			log.error("통과 토큰 발급 실패, 재시도 큐 등록 ({}/{}) - paceId={}, userId={}",
-				nextRetry, MAX_RETRY_COUNT, paceId, userIdStr, e);
-			retryQueue.addLast(userIdStr + RETRY_SEPARATOR + nextRetry);
-			return false;
+			log.error("파이프라인 실행 실패, 재시도 큐 등록 - paceId={}, count={}", paceId, entries.size(), e);
+			for (PassTokenEntry entry : entries) {
+				int nextRetry = entry.retryCount() + 1;
+				retryQueue.addLast(entry.userIdStr() + RETRY_SEPARATOR + nextRetry);
+			}
+			return 0;
 		}
 	}
 

--- a/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
+++ b/backend/queue/src/main/java/com/kt/onrace/queue/service/QueueService.java
@@ -1,9 +1,11 @@
 package com.kt.onrace.queue.service;
 
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.redisson.api.RBucket;
 import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RScript;
 import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.StringCodec;
@@ -29,6 +31,14 @@ public class QueueService {
 	private final RedissonClient redissonClient;
 	private final QueueMetrics queueMetrics;
 	private final QueueProperties queueProperties;
+
+	// GET passToken → 있으면 'PASS:{token}' 반환, 없으면 ZRANK 조회 → 'WAIT:{rank}' 반환, 둘 다 없으면 nil
+	private static final String STATUS_CHECK_SCRIPT =
+		"local pass = redis.call('GET', KEYS[1]); " +
+			"if pass then return 'PASS:' .. pass end; " +
+			"local rank = redis.call('ZRANK', KEYS[2], ARGV[1]); " +
+			"if rank ~= false then return 'WAIT:' .. rank end; " +
+			"return nil";
 
 	@ServiceLog
 	public QueueEnterResponse enter(Long userId, Long paceId) {
@@ -59,29 +69,34 @@ public class QueueService {
 
 	@ServiceLog
 	public QueueStatusResponse getStatus(Long userId, Long paceId) {
-		RBucket<String> passBucket = redissonClient.getBucket(
-			RedisKeyGenerator.queuePass(paceId, userId), StringCodec.INSTANCE);
-		String passToken = passBucket.get();
+		RScript script = redissonClient.getScript(StringCodec.INSTANCE);
+		String result = script.eval(
+			RScript.Mode.READ_ONLY,
+			STATUS_CHECK_SCRIPT,
+			RScript.ReturnType.VALUE,
+			List.of(
+				RedisKeyGenerator.queuePass(paceId, userId),
+				RedisKeyGenerator.queueWaiting(paceId)
+			),
+			String.valueOf(userId)
+		);
 
-		if (passToken != null) {
+		if (result == null) {
+			throw new BusinessException(BusinessErrorCode.QUEUE_NOT_FOUND);
+		}
+
+		if (result.startsWith("PASS:")) {
+			String passToken = result.substring(5);
 			log.info("[QUEUE] 통과 확인 userId={}, paceId={}", userId, paceId);
 			return QueueStatusResponse.pass(paceId, passToken);
 		}
 
-		RScoredSortedSet<String> waitingSet = redissonClient.getScoredSortedSet(
-			RedisKeyGenerator.queueWaiting(paceId), StringCodec.INSTANCE);
-		Integer rank = waitingSet.rank(String.valueOf(userId));
-
-		if (rank != null) {
-			long position = rank + 1;
-			long jitterMs = queueProperties.getPollJitterMs();
-			long retryAfterMs = queueProperties.getPollBaseMs()
-				+ (jitterMs > 0 ? ThreadLocalRandom.current().nextLong(jitterMs) : 0);
-			log.debug("[QUEUE] 대기 중 userId={}, paceId={}, position={}", userId, paceId, position);
-			return QueueStatusResponse.waiting(paceId, position, retryAfterMs);
-		}
-
-		throw new BusinessException(BusinessErrorCode.QUEUE_NOT_FOUND);
+		long position = Long.parseLong(result.substring(5)) + 1;
+		long jitterMs = queueProperties.getPollJitterMs();
+		long retryAfterMs = queueProperties.getPollBaseMs()
+			+ (jitterMs > 0 ? ThreadLocalRandom.current().nextLong(jitterMs) : 0);
+		log.debug("[QUEUE] 대기 중 userId={}, paceId={}, position={}", userId, paceId, position);
+		return QueueStatusResponse.waiting(paceId, position, retryAfterMs);
 	}
 
 	@ServiceLog

--- a/backend/queue/src/test/java/com/kt/onrace/queue/processor/QueueBatchSchedulerTest.java
+++ b/backend/queue/src/test/java/com/kt/onrace/queue/processor/QueueBatchSchedulerTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.redisson.api.RBucket;
+import org.redisson.api.BatchOptions;
+import org.redisson.api.RBatch;
+import org.redisson.api.RBucketAsync;
 import org.redisson.api.RDeque;
 import org.redisson.api.RLock;
 import org.redisson.api.RScoredSortedSet;
@@ -31,6 +32,7 @@ import org.redisson.api.RSet;
 import org.redisson.api.RedissonClient;
 import org.redisson.client.codec.Codec;
 
+import com.kt.onrace.queue.config.QueueMetrics;
 import com.kt.onrace.queue.config.QueueProperties;
 import com.kt.onrace.queue.security.QueueTokenGenerator;
 
@@ -48,12 +50,14 @@ class QueueBatchSchedulerTest {
 	@Mock private RedissonClient redissonClient;
 	@Mock private QueueProperties queueProperties;
 	@Mock private QueueTokenGenerator queueTokenGenerator;
+	@Mock private QueueMetrics queueMetrics;
 
 	@Mock private RSet<String> activePaces;
 	@Mock private RLock lock;
 	@Mock private RDeque<String> retryQueue;
 	@Mock private RScoredSortedSet<String> waitingSet;
-	@Mock private RBucket<String> passBucket;
+	@Mock private RBatch rBatch;
+	@Mock private RBucketAsync<String> batchBucket;
 	@Mock private RScript rScript;
 
 	@InjectMocks
@@ -107,9 +111,14 @@ class QueueBatchSchedulerTest {
 		when(waitingSet.pollFirst(any(int.class))).thenReturn(List.of());
 	}
 
+	private void givenPipelineBatch() {
+		when(redissonClient.createBatch(any(BatchOptions.class))).thenReturn(rBatch);
+		doReturn(batchBucket).when(rBatch).getBucket(anyString(), any(Codec.class));
+	}
+
 	private void givenTokenGeneration() {
 		when(queueTokenGenerator.generatePassToken(anyLong(), anyLong())).thenReturn(PASS_TOKEN);
-		doReturn(passBucket).when(redissonClient).getBucket(anyString(), any(Codec.class));
+		givenPipelineBatch();
 	}
 
 	private void givenLuaScript() {
@@ -123,7 +132,7 @@ class QueueBatchSchedulerTest {
 	class NormalFlow {
 
 		@Test
-		@DisplayName("대기열 사용자가 정상적으로 통과 토큰을 발급받는다")
+		@DisplayName("대기열 사용자가 파이프라인으로 통과 토큰을 발급받는다")
 		void processBatch_issuesPassToken() throws InterruptedException {
 			// given
 			givenBatchProperties();
@@ -139,12 +148,13 @@ class QueueBatchSchedulerTest {
 
 			// then
 			verify(queueTokenGenerator).generatePassToken(USER_ID, PACE_ID);
-			verify(passBucket).set(eq(PASS_TOKEN), eq(PASS_TTL), eq(TimeUnit.SECONDS));
+			verify(batchBucket).setAsync(eq(PASS_TOKEN), eq(PASS_TTL), eq(TimeUnit.SECONDS));
+			verify(rBatch).execute();
 			verify(lock).unlock();
 		}
 
 		@Test
-		@DisplayName("여러 pace가 각각 독립적으로 처리된다")
+		@DisplayName("여러 pace가 각각 독립적으로 병렬 처리된다")
 		void processBatch_multiPace() throws InterruptedException {
 			// given
 			givenBatchProperties();
@@ -161,6 +171,7 @@ class QueueBatchSchedulerTest {
 			// then
 			verify(lock, times(2)).tryLock(eq(0L), eq(30L), eq(TimeUnit.SECONDS));
 			verify(queueTokenGenerator, times(2)).generatePassToken(eq(USER_ID), anyLong());
+			verify(rBatch, times(2)).execute();
 		}
 	}
 
@@ -171,7 +182,7 @@ class QueueBatchSchedulerTest {
 	class RetryQueueTest {
 
 		@Test
-		@DisplayName("토큰 발급 실패 시 재시도 큐에 등록된다")
+		@DisplayName("토큰 생성 실패 시 재시도 큐에 등록된다")
 		void processBatch_tokenFailure_addedToRetryQueue() throws InterruptedException {
 			// given
 			givenBatchProperties();


### PR DESCRIPTION
## 🎯 작업 타겟 (Monorepo)

- [x] Backend
- [ ] Frontend
- [ ] AI
- [ ] Infra / DevOps

## 🔍 작업 내용 (What)
1차 개선
- 멤버 DB 조회 제거 (Gateway에서 조회하니 불필요)
- apply 시 이벤트/코스/페이스 조회 caffein 캐싱
- 재고 복구 이벤트 구독 방식으로 변경
- 페이스별 독립 대기열 배치 병렬 처리 도입
- 대기열 상태조회 통합

## 📸 스크린샷 / 아키텍처 / 로그 (필수)


## ❓ 변경 이유 (Why)
부하테스트 시 병목 구간 해소

## 📋 체크리스트

- [x] 로컬 환경에서 빌드 및 테스트 성공 확인
- [x] **민감 정보(AWS Key, DB 비번) 코드 내 하드코딩 없음 (OIDC/Secret 사용 확인)**
- [x] 불필요한 로그(`console.log`, `print`) 제거
- [x] **다른 서비스(예: 백엔드 수정 시 프론트)에 영향이 없는지 확인**

## 🔗 관련 이슈

Resolves: #
